### PR TITLE
[FEATURE] 교직 공지사항 조회, 배너 조회 기능 추가

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/banner/Banner.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/banner/Banner.java
@@ -1,0 +1,20 @@
+package depth.mvp.thinkerbell.domain.banner;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+@Table(name = "Banner")
+public class Banner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String s3Url;
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerController.java
@@ -1,7 +1,12 @@
 package depth.mvp.thinkerbell.domain.banner;
 
+
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,9 +20,19 @@ public class BannerController {
 
     private final BannerService bannerService;
 
+    @Operation(summary = "배너 이미지 조회", description = "배너 이미지를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
     @GetMapping
-    public ResponseEntity<List<BannerDTO>> getAllBanners() {
-        List<BannerDTO> banners = bannerService.getAllBanners();
-        return ResponseEntity.ok(banners);
+    public ApiResult<List<BannerDTO>> getAllBanners() {
+        try {
+            List<BannerDTO> banners = bannerService.getAllBanners();
+            return ApiResult.ok(banners);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerController.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.banner;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/banners")
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    public ResponseEntity<List<BannerDTO>> getAllBanners() {
+        List<BannerDTO> banners = bannerService.getAllBanners();
+        return ResponseEntity.ok(banners);
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerDTO.java
@@ -1,0 +1,20 @@
+package depth.mvp.thinkerbell.domain.banner;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BannerDTO {
+    private Long id;
+    private String title;
+    private String s3Url;
+
+    @Builder
+    public BannerDTO(Long id, String title, String s3Url) {
+        this.id = id;
+        this.title = title;
+        this.s3Url = s3Url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerRepository.java
@@ -1,0 +1,6 @@
+package depth.mvp.thinkerbell.domain.banner;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/banner/BannerService.java
@@ -1,0 +1,22 @@
+package depth.mvp.thinkerbell.domain.banner;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BannerService {
+
+    @Autowired
+    private BannerRepository bannerRepository;
+
+    public List<BannerDTO> getAllBanners() {
+        return bannerRepository.findAll().stream().map(banner -> new BannerDTO(
+                banner.getId(),
+                banner.getTitle(),
+                banner.getS3Url()
+        )).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
@@ -1,4 +1,41 @@
 package depth.mvp.thinkerbell.domain.notice.controller;
 
+import depth.mvp.thinkerbell.domain.notice.dto.TeachingNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.TeachingNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/teaching")
+@RequiredArgsConstructor
 public class TeachingController {
+
+    @Autowired
+    private final TeachingNoticeService teachingNoticeService;
+
+    @Operation(summary = "교직 공지사항 조회", description = "교직 공지사항을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<TeachingNoticeDTO>> getAllTeachingNotices() {
+        try {
+            List<TeachingNoticeDTO> notices = teachingNoticeService.getAllTeachingNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
@@ -1,0 +1,4 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+public class TeachingController {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
@@ -1,4 +1,26 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
 public class TeachingNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    private boolean isImportant;
+
+    @Builder
+    public TeachingNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean isImportant) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+        this.isImportant = isImportant;
+    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
@@ -1,0 +1,4 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+public class TeachingNoticeDTO {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
@@ -1,4 +1,7 @@
 package depth.mvp.thinkerbell.domain.notice.repository;
 
-public interface TeachingNoticeRepository {
+import depth.mvp.thinkerbell.domain.notice.entity.TeachingNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeachingNoticeRepository extends JpaRepository<TeachingNotice, Long> {
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
@@ -1,0 +1,4 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+public interface TeachingNoticeRepository {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
@@ -1,4 +1,22 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.TeachingNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.repository.TeachingNoticeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
 public class TeachingNoticeService {
+
+    @Autowired
+    private TeachingNoticeRepository teachingNoticeRepository;
+
+    public List<TeachingNoticeDTO> getAllTeachingNotices() {
+        return teachingNoticeRepository.findAll().stream().map(notice -> new TeachingNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl(), notice.isImportant()
+        )).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
@@ -1,0 +1,4 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+public class TeachingNoticeService {
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
- 교직 공지사항 조회[O] 
- 배너 조회[O]

## To Reviewers 💬
기능을 하나씩 했어야 했는데 뭔가가 잘 안되어서,, 이렇게 한번에 올립니당..죄송합니다. ㅠ,ㅠ
- 교직 공지사항 조회는 기존에 작성했던 나머지 공지사항들이랑 코드가 비슷합니다.
- 배너 조회같은 경우에는 S3에 배너 이미지파일 4개를 업로드 하였고, 그 URL을 RDS에 저장하였습니다. 

## Reference 🔬

