### PR TITLE
[FEATURE] alarm기능 및 FCM 전송 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/depth/mvp/thinkerbell/domain/common/service/CategoryService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/common/service/CategoryService.java
@@ -1,0 +1,34 @@
+package depth.mvp.thinkerbell.domain.common.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+@Service
+public class CategoryService {
+
+    private Map<String, String> categoryMap;
+
+    public CategoryService() {
+        loadCategoryMap();
+    }
+
+    private void loadCategoryMap() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try(InputStream inputStream = new ClassPathResource("Categories.json").getInputStream()) {
+            categoryMap = objectMapper.readValue(inputStream, new TypeReference<Map<String, String>>() {});
+        } catch (IOException e) {
+            throw new RuntimeException("카테고리 메핑 파일을 로드하는 동안 오류가 발생했습니다.",e);
+        }
+    }
+
+    public String getCategoryNameInKorean(String category) {
+        return categoryMap.getOrDefault(category, category);
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
@@ -29,10 +29,10 @@ public class AcademicNoticeController {
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/{isImportant}")
-    public ApiResult<List<AcademicNoticeDTO>> getAllAcademicNotices(@PathVariable("isImportant") boolean isImportant) {
+    @GetMapping("/{important}")
+    public ApiResult<List<AcademicNoticeDTO>> getAllAcademicNotices(@PathVariable("important") boolean important) {
         try {
-            List<AcademicNoticeDTO> notices = academicNoticeService.getAllAcademicNotices(isImportant);
+            List<AcademicNoticeDTO> notices = academicNoticeService.getAllAcademicNotices(important);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,22 +17,24 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AcademicNoticeController {
 
-    private final AcademicNoticeService academicNoticeService;
-
     @Operation(summary = "명지대 학사 공지사항 조회", description = "명지대 학사 공지사항을 조회합니다. (https://www.mju.ac" +
-            ".kr/mjukr/257/subview.do) 중요 공지를 조회할 땐 인자로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
+            ".kr/mjukr/257/subview.do) 중요 공지를 조회할 땐 인자(important)로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/{important}")
-    public ApiResult<List<AcademicNoticeDTO>> getAllAcademicNotices(@PathVariable("important") boolean important) {
+    @GetMapping
+    public ApiResult<List<AcademicNoticeDTO>> getAllAcademicNotices(@RequestParam(value = "important", required = false,
+            defaultValue = "false") boolean important,
+                                                                    @RequestParam("ssaid") String ssaid) {
         try {
-            List<AcademicNoticeDTO> notices = academicNoticeService.getAllAcademicNotices(important);
+            List<AcademicNoticeDTO> notices = academicNoticeService.getAllAcademicNotices(important, ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
         }
     }
+
+    private final AcademicNoticeService academicNoticeService;
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
@@ -1,0 +1,41 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.AcademicNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.AcademicNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/academic")
+@RequiredArgsConstructor
+public class AcademicNoticeController {
+
+    private final AcademicNoticeService academicNoticeService;
+
+    @Operation(summary = "명지대 학사 공지사항 조회", description = "명지대 학사 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/257/subview.do) 중요 공지를 조회할 땐 인자로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/{isImportant}")
+    public ApiResult<List<AcademicNoticeDTO>> getAllAcademicNotices(@PathVariable("isImportant") boolean isImportant) {
+        try {
+            List<AcademicNoticeDTO> notices = academicNoticeService.getAllAcademicNotices(isImportant);
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/BiddingNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/BiddingNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class BiddingNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<BiddingNoticeDTO>> getAllBiddingNotices() {
+    public ApiResult<List<BiddingNoticeDTO>> getAllBiddingNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<BiddingNoticeDTO> notices = biddingNoticeService.getAllBiddingNotices();
+            List<BiddingNoticeDTO> notices = biddingNoticeService.getAllBiddingNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/BiddingNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/BiddingNoticeController.java
@@ -1,0 +1,40 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.BiddingNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/bidding")
+@RequiredArgsConstructor
+public class BiddingNoticeController {
+
+    private final BiddingNoticeService biddingNoticeService;
+
+    @Operation(summary = "명지대 입찰 공지사항 조회", description = "명지대 입찰 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/261/subview.do)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<BiddingNoticeDTO>> getAllBiddingNotices() {
+        try {
+            List<BiddingNoticeDTO> notices = biddingNoticeService.getAllBiddingNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/CareerNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/CareerNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class CareerNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<CareerNoticeDTO>> getAllCareerNotices() {
+    public ApiResult<List<CareerNoticeDTO>> getAllCareerNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<CareerNoticeDTO> notices = careerNoticeService.getAllCareerNotices();
+            List<CareerNoticeDTO> notices = careerNoticeService.getAllCareerNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/CareerNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/CareerNoticeController.java
@@ -1,0 +1,40 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.CareerNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.CareerNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/career")
+@RequiredArgsConstructor
+public class CareerNoticeController {
+
+    private final CareerNoticeService careerNoticeService;
+
+    @Operation(summary = "명지대 진로/취업/창업 공지사항 조회", description = "명지대 진로/취업/창업 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/260/subview.do)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<CareerNoticeDTO>> getAllCareerNotices() {
+        try {
+            List<CareerNoticeDTO> notices = careerNoticeService.getAllCareerNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/DormitoryController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/DormitoryController.java
@@ -33,9 +33,10 @@ public class DormitoryController {
     @GetMapping("/notices")
     public ApiResult<PaginationDTO<DormitoryNoticeDTO>> getImportantNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<DormitoryNoticeDTO> paginationDTO = dormitoryNoticeService.getImportantNotices(page, size);
+            PaginationDTO<DormitoryNoticeDTO> paginationDTO = dormitoryNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
@@ -51,9 +52,11 @@ public class DormitoryController {
     @GetMapping("/entry-notices")
     public ApiResult<PaginationDTO<DormitoryEntryNoticeDTO>> getImportantEntryNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<DormitoryEntryNoticeDTO> paginationDTO = dormitoryEntryNoticeService.getImportantNotices(page, size);
+            PaginationDTO<DormitoryEntryNoticeDTO> paginationDTO =
+                    dormitoryEntryNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/EventNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/EventNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class EventNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<EventNoticeDTO>> getAllEventNotices() {
+    public ApiResult<List<EventNoticeDTO>> getAllEventNotices(@RequestParam("ssaid")String ssaid) {
         try {
-            List<EventNoticeDTO> notices = eventNoticeService.getAllEventNotices();
+            List<EventNoticeDTO> notices = eventNoticeService.getAllEventNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/EventNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/EventNoticeController.java
@@ -1,0 +1,40 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.EventNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.EventNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/event")
+@RequiredArgsConstructor
+public class EventNoticeController {
+
+    private final EventNoticeService eventNoticeService;
+
+    @Operation(summary = "명지대 행사 공지사항 조회", description = "명지대 행사 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/256/subview.do)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<EventNoticeDTO>> getAllEventNotices() {
+        try {
+            List<EventNoticeDTO> notices = eventNoticeService.getAllEventNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/JobTrainingController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/JobTrainingController.java
@@ -2,6 +2,7 @@ package depth.mvp.thinkerbell.domain.notice.controller;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.JobTrainingNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.DormitoryNoticeService;
 import depth.mvp.thinkerbell.domain.notice.service.JobTrainingNoticeService;
 import depth.mvp.thinkerbell.global.dto.ApiResult;
 import depth.mvp.thinkerbell.global.exception.ErrorCode;
@@ -31,9 +32,11 @@ public class JobTrainingController {
     @GetMapping
     public ApiResult<PaginationDTO<JobTrainingNoticeDTO>> getJobTrainingNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<JobTrainingNoticeDTO> paginationDTO = jobTrainingNoticeService.getJobTrainingNotices(page, size);
+            PaginationDTO<JobTrainingNoticeDTO> paginationDTO = jobTrainingNoticeService.getJobTrainingNotices(page,
+                    size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/LibraryController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/LibraryController.java
@@ -33,9 +33,10 @@ public class LibraryController {
     @GetMapping
     public ApiResult<PaginationDTO<LibraryNoticeDTO>> getImportantLibraryNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<LibraryNoticeDTO> paginationDTO = libraryNoticeService.getImportantNotices(page, size);
+            PaginationDTO<LibraryNoticeDTO> paginationDTO = libraryNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
@@ -1,0 +1,41 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.NormalNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/normal")
+@RequiredArgsConstructor
+public class NormalNoticeController {
+
+    private final NormalNoticeService normalNoticeService;
+
+    @Operation(summary = "명지대 일반 공지사항 조회", description = "명지대 일반 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/255/subview.do) 중요 공지를 조회할 땐 인자로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/{isImportant}")
+    public ApiResult<List<NormalNoticeDTO>> getAllNormalNotices(@PathVariable("isImportant") boolean isImportant) {
+        try {
+            List<NormalNoticeDTO> notices = normalNoticeService.getAllNormalNotices(isImportant);
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,16 +20,18 @@ public class NormalNoticeController {
     private final NormalNoticeService normalNoticeService;
 
     @Operation(summary = "명지대 일반 공지사항 조회", description = "명지대 일반 공지사항을 조회합니다. (https://www.mju.ac" +
-            ".kr/mjukr/255/subview.do) 중요 공지를 조회할 땐 인자로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
+            ".kr/mjukr/255/subview.do) 중요 공지를 조회할 땐 인자(important)로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/{important}")
-    public ApiResult<List<NormalNoticeDTO>> getAllNormalNotices(@PathVariable("important") boolean important) {
+    @GetMapping
+    public ApiResult<List<NormalNoticeDTO>> getAllNormalNotices(@RequestParam(value = "important", required = false,
+                                                                              defaultValue = "false") boolean important,
+                                                                @RequestParam("ssaid") String ssaid) {
         try {
-            List<NormalNoticeDTO> notices = normalNoticeService.getAllNormalNotices(important);
+            List<NormalNoticeDTO> notices = normalNoticeService.getAllNormalNotices(important, ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
@@ -29,10 +29,10 @@ public class NormalNoticeController {
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/{isImportant}")
-    public ApiResult<List<NormalNoticeDTO>> getAllNormalNotices(@PathVariable("isImportant") boolean isImportant) {
+    @GetMapping("/{important}")
+    public ApiResult<List<NormalNoticeDTO>> getAllNormalNotices(@PathVariable("important") boolean important) {
         try {
-            List<NormalNoticeDTO> notices = normalNoticeService.getAllNormalNotices(isImportant);
+            List<NormalNoticeDTO> notices = normalNoticeService.getAllNormalNotices(important);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/RevisionNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/RevisionNoticeController.java
@@ -1,0 +1,40 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.RevisionNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.RevisionNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/revision")
+@RequiredArgsConstructor
+public class RevisionNoticeController {
+
+    private final RevisionNoticeService revisionNoticeService;
+
+    @Operation(summary = "명지대 학칙개정 사전공고 조회", description = "명지대 학칙개정 사전공고를 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/4450/subview.do)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<RevisionNoticeDTO>> getAllRevisionNotices() {
+        try {
+            List<RevisionNoticeDTO> notices = revisionNoticeService.getAllRevisionNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/RevisionNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/RevisionNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class RevisionNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<RevisionNoticeDTO>> getAllRevisionNotices() {
+    public ApiResult<List<RevisionNoticeDTO>> getAllRevisionNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<RevisionNoticeDTO> notices = revisionNoticeService.getAllRevisionNotices();
+            List<RevisionNoticeDTO> notices = revisionNoticeService.getAllRevisionNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/SafetyNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/SafetyNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class SafetyNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<SafetyNoticeDTO>> getAllSafetyNotices() {
+    public ApiResult<List<SafetyNoticeDTO>> getAllSafetyNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<SafetyNoticeDTO> notices = safetyNoticeService.getAllSafetyNotices();
+            List<SafetyNoticeDTO> notices = safetyNoticeService.getAllSafetyNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/SafetyNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/SafetyNoticeController.java
@@ -1,0 +1,40 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.SafetyNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.SafetyNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/safety")
+@RequiredArgsConstructor
+public class SafetyNoticeController {
+
+    private final SafetyNoticeService safetyNoticeService;
+
+    @Operation(summary = "명지대 대학안전 공지사항 조회", description = "명지대 대학안전 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/8972/subview.do)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<SafetyNoticeDTO>> getAllSafetyNotices() {
+        try {
+            List<SafetyNoticeDTO> notices = safetyNoticeService.getAllSafetyNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/ScholarshipNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/ScholarshipNoticeController.java
@@ -1,0 +1,42 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.EventNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.ScholarshipNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.EventNoticeService;
+import depth.mvp.thinkerbell.domain.notice.service.ScholarshipNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/scholarship")
+@RequiredArgsConstructor
+public class ScholarshipNoticeController {
+
+    private final ScholarshipNoticeService scholarshipNoticeService;
+
+    @Operation(summary = "명지대 장학/학자금 공지사항 조회", description = "명지대 장학/학자금 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/259/subview.do)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<ScholarshipNoticeDTO>> getAllScholarshipNotices() {
+        try {
+            List<ScholarshipNoticeDTO> notices = scholarshipNoticeService.getAllScholarshipNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/ScholarshipNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/ScholarshipNoticeController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -31,9 +32,9 @@ public class ScholarshipNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<ScholarshipNoticeDTO>> getAllScholarshipNotices() {
+    public ApiResult<List<ScholarshipNoticeDTO>> getAllScholarshipNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<ScholarshipNoticeDTO> notices = scholarshipNoticeService.getAllScholarshipNotices();
+            List<ScholarshipNoticeDTO> notices = scholarshipNoticeService.getAllScholarshipNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/StudentActsNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/StudentActsNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class StudentActsNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<StudentActsNoticeDTO>> getAllStudentActsNotices() {
+    public ApiResult<List<StudentActsNoticeDTO>> getAllStudentActsNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<StudentActsNoticeDTO> notices = studentActsNoticeService.getAllStudentActsNotices();
+            List<StudentActsNoticeDTO> notices = studentActsNoticeService.getAllStudentActsNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/StudentActsNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/StudentActsNoticeController.java
@@ -1,0 +1,40 @@
+package depth.mvp.thinkerbell.domain.notice.controller;
+
+import depth.mvp.thinkerbell.domain.notice.dto.StudentActsNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.StudentActsNoticeService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/student-acts")
+@RequiredArgsConstructor
+public class StudentActsNoticeController {
+
+    private final StudentActsNoticeService studentActsNoticeService;
+
+    @Operation(summary = "명지대 학생활동 공지사항 조회", description = "명지대 학생활동 공지사항을 조회합니다. (https://www.mju.ac" +
+            ".kr/mjukr/5364/subview.do)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping
+    public ApiResult<List<StudentActsNoticeDTO>> getAllStudentActsNotices() {
+        try {
+            List<StudentActsNoticeDTO> notices = studentActsNoticeService.getAllStudentActsNotices();
+            return ApiResult.ok(notices);
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
@@ -32,9 +32,10 @@ public class TeachingController {
     @GetMapping
     public ApiResult<PaginationDTO<TeachingNoticeDTO>> getImportantTeachingNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<TeachingNoticeDTO> paginationDTO = teachingNoticeService.getImportantNotices(page, size);
+            PaginationDTO<TeachingNoticeDTO> paginationDTO = teachingNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
@@ -13,14 +13,16 @@ public class AcademicNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     private boolean important;
 
     @Builder
-    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean important) {
+    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
         this.important = important;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
@@ -1,0 +1,26 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class AcademicNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    private boolean isImportant;
+
+    @Builder
+    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean isImportant) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+        this.isImportant = isImportant;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
@@ -13,14 +13,14 @@ public class AcademicNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
-    private boolean isImportant;
+    private boolean important;
 
     @Builder
-    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean isImportant) {
+    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean important) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
-        this.isImportant = isImportant;
+        this.important = important;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
@@ -1,13 +1,15 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class AcademicNoticeDTO {
     private Long id;
     private LocalDate pubDate;
@@ -16,13 +18,4 @@ public class AcademicNoticeDTO {
     private boolean marked;
     private boolean important;
 
-    @Builder
-    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-        this.important = important;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicScheduleDto.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicScheduleDto.java
@@ -1,6 +1,9 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
@@ -1,13 +1,15 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class BiddingNoticeDTO {
     private Long id;
     private LocalDate pubDate;
@@ -15,12 +17,4 @@ public class BiddingNoticeDTO {
     private String url;
     private boolean marked;
 
-    @Builder
-    public BiddingNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
@@ -13,11 +13,14 @@ public class BiddingNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
+
     @Builder
-    public BiddingNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public BiddingNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class BiddingNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    @Builder
+    public BiddingNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
@@ -13,11 +13,13 @@ public class CareerNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public CareerNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public CareerNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
@@ -1,25 +1,20 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class CareerNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public CareerNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
+
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class CareerNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    @Builder
+    public CareerNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryEntryNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryEntryNoticeDTO.java
@@ -2,29 +2,33 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryEntryNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class DormitoryEntryNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private boolean isImportant;
+    private boolean marked;
+    private boolean important;
     private String campus;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static DormitoryEntryNoticeDTO fromEntity(DormitoryEntryNotice notice) {
-        return new DormitoryEntryNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant(),
-                notice.getCampus()
-        );
-    }
+//    public static DormitoryEntryNoticeDTO fromEntity(DormitoryEntryNotice notice) {
+//        return new DormitoryEntryNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant(),
+//                notice.getCampus()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryNoticeDTO.java
@@ -2,30 +2,33 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class DormitoryNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private boolean isImportant;
+    private boolean marked;
+    private boolean important;
     private String campus;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static DormitoryNoticeDTO fromEntity(DormitoryNotice notice) {
-        return new DormitoryNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant(),
-                notice.getCampus()
-        );
-    }
-
+//    public static DormitoryNoticeDTO fromEntity(DormitoryNotice notice) {
+//        return new DormitoryNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant(),
+//                notice.getCampus()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
@@ -1,25 +1,20 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class EventNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public EventNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
+
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
@@ -13,11 +13,13 @@ public class EventNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public EventNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public EventNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class EventNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    @Builder
+    public EventNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/JobTrainingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/JobTrainingNoticeDTO.java
@@ -2,10 +2,12 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.JobTrainingNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
+@Builder
 public class JobTrainingNoticeDTO {
     private String company;
     private String year;
@@ -15,18 +17,19 @@ public class JobTrainingNoticeDTO {
     private String recrutingNum;
     private String deadline;
     private String jobName;
+    private boolean marked;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static JobTrainingNoticeDTO fromEntity(JobTrainingNotice notice) {
-        return new JobTrainingNoticeDTO(
-                notice.getCompany(),
-                notice.getYear(),
-                notice.getSemester(),
-                notice.getPeriod(),
-                notice.getMajor(),
-                notice.getRecrutingNum(),
-                notice.getDeadline(),
-                notice.getJobName()
-        );
-    }
+//    public static JobTrainingNoticeDTO fromEntity(JobTrainingNotice notice) {
+//        return new JobTrainingNoticeDTO(
+//                notice.getCompany(),
+//                notice.getYear(),
+//                notice.getSemester(),
+//                notice.getPeriod(),
+//                notice.getMajor(),
+//                notice.getRecrutingNum(),
+//                notice.getDeadline(),
+//                notice.getJobName()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/LibraryNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/LibraryNoticeDTO.java
@@ -7,23 +7,25 @@ import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class LibraryNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private Boolean isImportant;
+    private boolean marked;
+    private Boolean important;
     private String campus;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static LibraryNoticeDTO fromEntity(LibraryNotice notice) {
-        return new LibraryNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant(),
-                notice.getCampus()
-        );
-    }
+//    public static LibraryNoticeDTO fromEntity(LibraryNotice notice) {
+//        return new LibraryNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant(),
+//                notice.getCampus()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
@@ -13,14 +13,16 @@ public class NormalNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     private boolean important;
 
     @Builder
-    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean important) {
+    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
         this.important = important;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
@@ -13,14 +13,14 @@ public class NormalNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
-    private boolean isImportant;
+    private boolean important;
 
     @Builder
-    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean isImportant) {
+    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean important) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
-        this.isImportant = isImportant;
+        this.important = important;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
@@ -1,0 +1,26 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class NormalNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    private boolean isImportant;
+
+    @Builder
+    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean isImportant) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+        this.isImportant = isImportant;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
@@ -1,13 +1,15 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class NormalNoticeDTO {
     private Long id;
     private LocalDate pubDate;
@@ -16,13 +18,4 @@ public class NormalNoticeDTO {
     private boolean marked;
     private boolean important;
 
-    @Builder
-    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-        this.important = important;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
@@ -13,11 +13,13 @@ public class RevisionNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public RevisionNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public RevisionNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
@@ -1,25 +1,20 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class RevisionNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public RevisionNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
+
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class RevisionNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    @Builder
+    public RevisionNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
@@ -1,25 +1,19 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class SafetyNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public SafetyNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
@@ -13,11 +13,13 @@ public class SafetyNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public SafetyNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public SafetyNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class SafetyNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    @Builder
+    public SafetyNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
@@ -1,25 +1,19 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class ScholarshipNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public ScholarshipNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
@@ -13,11 +13,13 @@ public class ScholarshipNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public ScholarshipNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public ScholarshipNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class ScholarshipNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    @Builder
+    public ScholarshipNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
@@ -13,11 +13,13 @@ public class StudentActsNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public StudentActsNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public StudentActsNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
@@ -1,25 +1,19 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class StudentActsNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public StudentActsNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
@@ -1,0 +1,23 @@
+package depth.mvp.thinkerbell.domain.notice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class StudentActsNoticeDTO {
+    private Long id;
+    private LocalDate pubDate;
+    private String title;
+    private String url;
+    @Builder
+    public StudentActsNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+        this.id = id;
+        this.pubDate = pubDate;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
@@ -2,26 +2,29 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.TeachingNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @AllArgsConstructor
 @Getter
+@Builder
 public class TeachingNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private Boolean isImportant;
+    private Boolean important;
+    private boolean marked;
 
-    public static TeachingNoticeDTO fromEntity(TeachingNotice notice) {
-        return new TeachingNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant()
-        );
-    }
+//    public static TeachingNoticeDTO fromEntity(TeachingNotice notice) {
+//        return new TeachingNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/AcademicNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/AcademicNotice.java
@@ -20,18 +20,19 @@ public class AcademicNotice extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private boolean isImportant;
+    @Column(name = "is_important")
+    private boolean important;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public AcademicNotice(String title, String url, LocalDate pubDate, boolean isImportant, Univ univ) {
+    public AcademicNotice(String title, String url, LocalDate pubDate, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/CrawlingNum.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/CrawlingNum.java
@@ -1,14 +1,12 @@
 package depth.mvp.thinkerbell.domain.notice.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
+@Setter
 @Table(name = "Crawling_Num")
 public class CrawlingNum {
 

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryEntryNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryEntryNotice.java
@@ -22,18 +22,18 @@ public class DormitoryEntryNotice extends BaseEntity {
 
     private String campus;
 
-    private boolean isImportant;
+    private boolean important;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public DormitoryEntryNotice(String title, String url, LocalDate pubDate, String campus, boolean isImportant, Univ univ) {
+    public DormitoryEntryNotice(String title, String url, LocalDate pubDate, String campus, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
         this.campus = campus;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryNotice.java
@@ -22,19 +22,19 @@ public class DormitoryNotice extends BaseEntity {
 
     private String campus;
 
-    private boolean isImportant;
+    private boolean important;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
 
     @Builder
-    public DormitoryNotice(String title, String url, LocalDate pubDate, String campus, boolean isImportant, Univ univ) {
+    public DormitoryNotice(String title, String url, LocalDate pubDate, String campus, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
         this.campus = campus;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/LibraryNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/LibraryNotice.java
@@ -22,19 +22,19 @@ public class LibraryNotice extends BaseEntity {
 
     private String campus;
 
-    private boolean isImportant;
+    private boolean important;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public LibraryNotice(String title, String url, LocalDate pubDate, String campus, boolean isImportant,  Univ univ) {
+    public LibraryNotice(String title, String url, LocalDate pubDate, String campus, boolean important,  Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
         this.campus = campus;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/NormalNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/NormalNotice.java
@@ -19,19 +19,19 @@ public class NormalNotice extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private boolean isImportant;
+    @Column(name = "is_important")
+    private boolean important;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public NormalNotice(String title, String url, LocalDate pubDate, boolean isImportant, Univ univ) {
+    public NormalNotice(String title, String url, LocalDate pubDate, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/SafetyNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/SafetyNotice.java
@@ -1,0 +1,34 @@
+package depth.mvp.thinkerbell.domain.notice.entity;
+
+import depth.mvp.thinkerbell.domain.common.entity.BaseEntity;
+import depth.mvp.thinkerbell.domain.common.entity.Univ;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+@Table(name = "Safety_Notice")
+public class SafetyNotice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "univ_id")
+    private Univ univ;
+
+    @Builder
+    public SafetyNotice(String title, String url, LocalDate pubDate, Univ univ) {
+        this.title = title;
+        this.url = url;
+        this.pubDate = pubDate;
+        this.univ = univ;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/TeachingNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/TeachingNotice.java
@@ -20,17 +20,17 @@ public class TeachingNotice extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private boolean isImportant;
+    private boolean important;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public TeachingNotice(String title, String url, LocalDate pubDate, boolean isImportant, Univ univ) {
+    public TeachingNotice(String title, String url, LocalDate pubDate, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AcademicNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AcademicNoticeRepository.java
@@ -1,0 +1,12 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.AcademicNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AcademicNoticeRepository extends JpaRepository<AcademicNotice, Long> {
+    List<AcademicNotice> findByIsImportant(boolean isImportant);
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AcademicNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AcademicNoticeRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface AcademicNoticeRepository extends JpaRepository<AcademicNotice, Long> {
-    List<AcademicNotice> findByIsImportant(boolean isImportant);
+    List<AcademicNotice> findByImportant(boolean important);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AllNoticeViewRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AllNoticeViewRepository.java
@@ -10,4 +10,10 @@ import java.util.List;
 public interface AllNoticeViewRepository extends JpaRepository<AllNoticesView, Long> {
     @Query(value = "SELECT * FROM All_Notices_View e WHERE REPLACE(e.title, ' ', '') LIKE %:keyword%", nativeQuery = true)
     List<AllNoticesView> findByTitleContainingKeyword(@Param("keyword") String keyword);
+
+    @Query(value = "SELECT * FROM All_Notices_View WHERE table_name = :category AND id > :maxId", nativeQuery = true)
+    List<AllNoticesView> findNewNoticesByCategory(@Param("category") String category, @Param("maxId") Long maxId);
+
+    @Query(value = "SELECT MAX(id) FROM All_Notices_View WHERE table_name = :category", nativeQuery = true)
+    Long findMaxIdByCategory(@Param("category") String category);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/BiddingNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/BiddingNoticeRepository.java
@@ -1,0 +1,10 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.BiddingNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface BiddingNoticeRepository extends JpaRepository<BiddingNotice, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/CareerNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/CareerNoticeRepository.java
@@ -1,0 +1,9 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.CareerNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CareerNoticeRepository extends JpaRepository<CareerNotice, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/CrawlingNumRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/CrawlingNumRepository.java
@@ -1,0 +1,10 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.CrawlingNum;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CrawlingNumRepository extends JpaRepository<CrawlingNum, Long> {
+    Optional<CrawlingNum> findByNoticeType(String noticeType);
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DormitoryEntryNoticeRepository extends JpaRepository<DormitoryEntryNotice, Long> {
-    Page<DormitoryEntryNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<DormitoryEntryNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DormitoryNoticeRepository extends JpaRepository<DormitoryNotice, Long> {
-    Page<DormitoryNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<DormitoryNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/EventNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/EventNoticeRepository.java
@@ -1,0 +1,9 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.EventNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventNoticeRepository extends JpaRepository<EventNotice, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LibraryNoticeRepository extends JpaRepository<LibraryNotice, Long> {
-    Page<LibraryNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<LibraryNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/NormalNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/NormalNoticeRepository.java
@@ -1,0 +1,12 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.NormalNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NormalNoticeRepository  extends JpaRepository<NormalNotice, Long> {
+    List<NormalNotice> findByIsImportant(boolean isImportant);
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/NormalNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/NormalNoticeRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface NormalNoticeRepository  extends JpaRepository<NormalNotice, Long> {
-    List<NormalNotice> findByIsImportant(boolean isImportant);
+    List<NormalNotice> findByImportant(boolean important);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/RevisionNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/RevisionNoticeRepository.java
@@ -1,0 +1,10 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.RevisionNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface RevisionNoticeRepository extends JpaRepository<RevisionNotice, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/SafetyNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/SafetyNoticeRepository.java
@@ -1,0 +1,10 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.SafetyNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface SafetyNoticeRepository extends JpaRepository<SafetyNotice, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/ScholarshipNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/ScholarshipNoticeRepository.java
@@ -1,0 +1,10 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.EventNotice;
+import depth.mvp.thinkerbell.domain.notice.entity.ScholarshipNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScholarshipNoticeRepository extends JpaRepository<ScholarshipNotice, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/StudentActsNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/StudentActsNoticeRepository.java
@@ -1,0 +1,10 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.StudentActsNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface StudentActsNoticeRepository extends JpaRepository<StudentActsNotice, Long> {
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeachingNoticeRepository extends JpaRepository<TeachingNotice, Long> {
-    Page<TeachingNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<TeachingNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
@@ -1,8 +1,12 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.notice.dto.AcademicNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.AcademicNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.AcademicNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.repository.BookmarkRepository;
+import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +15,33 @@ import java.util.stream.Collectors;
 
 @Service
 public class AcademicNoticeService {
+    private final BookmarkService bookmarkService;
     private final AcademicNoticeRepository academicNoticeRepository;
 
-    public AcademicNoticeService(AcademicNoticeRepository academicNoticeRepository) {
+    public AcademicNoticeService(BookmarkService bookmarkService, AcademicNoticeRepository academicNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.academicNoticeRepository = academicNoticeRepository;
     }
 
-    public List<AcademicNoticeDTO> getAllAcademicNotices(boolean important) throws NotFoundException {
+    public List<AcademicNoticeDTO> getAllAcademicNotices(boolean important, String ssaid) throws NotFoundException {
         List<AcademicNotice> notices = academicNoticeRepository.findByImportant(important);
         if (notices == null || notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new AcademicNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl(), notice.isImportant()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return AcademicNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .important(notice.isImportant())
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.AcademicNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.AcademicNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.AcademicNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AcademicNoticeService {
+    private final AcademicNoticeRepository academicNoticeRepository;
+
+    public AcademicNoticeService(AcademicNoticeRepository academicNoticeRepository) {
+        this.academicNoticeRepository = academicNoticeRepository;
+    }
+
+    public List<AcademicNoticeDTO> getAllAcademicNotices(boolean isImportant) throws NotFoundException {
+        List<AcademicNotice> notices = academicNoticeRepository.findByIsImportant(isImportant);
+        if (notices == null || notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new AcademicNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl(), notice.isImportant()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
@@ -17,8 +17,8 @@ public class AcademicNoticeService {
         this.academicNoticeRepository = academicNoticeRepository;
     }
 
-    public List<AcademicNoticeDTO> getAllAcademicNotices(boolean isImportant) throws NotFoundException {
-        List<AcademicNotice> notices = academicNoticeRepository.findByIsImportant(isImportant);
+    public List<AcademicNoticeDTO> getAllAcademicNotices(boolean important) throws NotFoundException {
+        List<AcademicNotice> notices = academicNoticeRepository.findByImportant(important);
         if (notices == null || notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/BiddingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/BiddingNoticeService.java
@@ -1,11 +1,10 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
-import depth.mvp.thinkerbell.domain.notice.dto.StudentActsNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.BiddingNotice;
-import depth.mvp.thinkerbell.domain.notice.entity.StudentActsNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.BiddingNoticeRepository;
-import depth.mvp.thinkerbell.domain.notice.repository.StudentActsNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -14,20 +13,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class BiddingNoticeService {
+    private final BookmarkService bookmarkService;
     private final BiddingNoticeRepository biddingNoticeRepository;
 
-    public BiddingNoticeService(BiddingNoticeRepository biddingNoticeRepository) {
+    public BiddingNoticeService(BookmarkService bookmarkService, BiddingNoticeRepository biddingNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.biddingNoticeRepository = biddingNoticeRepository;
     }
 
-    public List<BiddingNoticeDTO> getAllBiddingNotices() throws NotFoundException {
+    public List<BiddingNoticeDTO> getAllBiddingNotices(String ssaid) throws NotFoundException {
         List<BiddingNotice> notices = biddingNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new BiddingNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return BiddingNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/BiddingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/BiddingNoticeService.java
@@ -1,0 +1,33 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.StudentActsNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.BiddingNotice;
+import depth.mvp.thinkerbell.domain.notice.entity.StudentActsNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.BiddingNoticeRepository;
+import depth.mvp.thinkerbell.domain.notice.repository.StudentActsNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BiddingNoticeService {
+    private final BiddingNoticeRepository biddingNoticeRepository;
+
+    public BiddingNoticeService(BiddingNoticeRepository biddingNoticeRepository) {
+        this.biddingNoticeRepository = biddingNoticeRepository;
+    }
+
+    public List<BiddingNoticeDTO> getAllBiddingNotices() throws NotFoundException {
+        List<BiddingNotice> notices = biddingNoticeRepository.findAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new BiddingNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/CareerNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/CareerNoticeService.java
@@ -1,8 +1,11 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.CareerNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.CareerNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.CareerNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +14,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class CareerNoticeService {
+    private final BookmarkService bookmarkService;
     private final CareerNoticeRepository careerNoticeRepository;
 
-    public CareerNoticeService(CareerNoticeRepository careerNoticeRepository) {
+    public CareerNoticeService(BookmarkService bookmarkService, CareerNoticeRepository careerNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.careerNoticeRepository = careerNoticeRepository;
     }
 
-    public List<CareerNoticeDTO> getAllCareerNotices() throws NotFoundException {
+    public List<CareerNoticeDTO> getAllCareerNotices(String ssaid) throws NotFoundException {
         List<CareerNotice> notices = careerNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new CareerNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return CareerNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/CareerNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/CareerNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.CareerNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.CareerNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.CareerNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CareerNoticeService {
+    private final CareerNoticeRepository careerNoticeRepository;
+
+    public CareerNoticeService(CareerNoticeRepository careerNoticeRepository) {
+        this.careerNoticeRepository = careerNoticeRepository;
+    }
+
+    public List<CareerNoticeDTO> getAllCareerNotices() throws NotFoundException {
+        List<CareerNotice> notices = careerNoticeRepository.findAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new CareerNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
@@ -2,8 +2,10 @@ package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.DormitoryEntryNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryEntryNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.DormitoryEntryNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,9 +17,13 @@ import java.util.stream.Collectors;
 
 @Service
 public class DormitoryEntryNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private DormitoryEntryNoticeRepository dormitoryEntryNoticeRepository;
+
+    public DormitoryEntryNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
 
 //    public List<DormitoryEntryNoticeDTO> getAllEntryNotices() {
 //        return dormitoryEntryNoticeRepository.findAll().stream().map(notice -> new DormitoryEntryNoticeDTO(
@@ -26,12 +32,29 @@ public class DormitoryEntryNoticeService {
 //        )).collect(Collectors.toList());
 //    }
 
-    public PaginationDTO<DormitoryEntryNoticeDTO> getImportantNotices(int page, int size) {
+    public PaginationDTO<DormitoryEntryNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<DormitoryEntryNotice> resultPage = dormitoryEntryNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<DormitoryEntryNotice> resultPage = dormitoryEntryNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<DormitoryEntryNoticeDTO> dtoList = resultPage.stream()
+//                .map(DormitoryEntryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<DormitoryEntryNoticeDTO> dtoList = resultPage.stream()
-                .map(DormitoryEntryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return DormitoryEntryNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
 
         return new PaginationDTO<>(

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
@@ -4,6 +4,7 @@ import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.DormitoryNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,9 +16,13 @@ import java.util.stream.Collectors;
 
 @Service
 public class DormitoryNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private DormitoryNoticeRepository dormitoryNoticeRepository;
+
+    public DormitoryNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
 
 //    public List<DormitoryNoticeDTO> getAllNotices() {
 //        return dormitoryNoticeRepository.findAll().stream().map(notice -> new DormitoryNoticeDTO(
@@ -26,14 +31,30 @@ public class DormitoryNoticeService {
 //        )).collect(Collectors.toList());
 //    }
 
-    public PaginationDTO<DormitoryNoticeDTO> getImportantNotices(int page, int size) {
+    public PaginationDTO<DormitoryNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<DormitoryNotice> resultPage = dormitoryNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<DormitoryNotice> resultPage = dormitoryNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<DormitoryNoticeDTO> dtoList = resultPage.stream()
+//                .map(DormitoryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<DormitoryNoticeDTO> dtoList = resultPage.stream()
-                .map(DormitoryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return DormitoryNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
-
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/EventNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/EventNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.EventNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.EventNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.EventNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class EventNoticeService {
+    private final EventNoticeRepository eventNoticeRepository;
+
+    public EventNoticeService(EventNoticeRepository eventNoticeRepository) {
+        this.eventNoticeRepository = eventNoticeRepository;
+    }
+
+    public List<EventNoticeDTO> getAllEventNotices() throws NotFoundException {
+        List<EventNotice> notices = eventNoticeRepository.findAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new EventNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/EventNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/EventNoticeService.java
@@ -3,6 +3,7 @@ package depth.mvp.thinkerbell.domain.notice.service;
 import depth.mvp.thinkerbell.domain.notice.dto.EventNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.EventNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.EventNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +12,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class EventNoticeService {
+    private final BookmarkService bookmarkService;
     private final EventNoticeRepository eventNoticeRepository;
 
-    public EventNoticeService(EventNoticeRepository eventNoticeRepository) {
+    public EventNoticeService(BookmarkService bookmarkService, EventNoticeRepository eventNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.eventNoticeRepository = eventNoticeRepository;
     }
 
-    public List<EventNoticeDTO> getAllEventNotices() throws NotFoundException {
+    public List<EventNoticeDTO> getAllEventNotices(String ssaid) throws NotFoundException {
         List<EventNotice> notices = eventNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new EventNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return EventNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/JobTrainingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/JobTrainingNoticeService.java
@@ -1,9 +1,11 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.JobTrainingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.JobTrainingNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.JobTrainingNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,18 +17,41 @@ import java.util.stream.Collectors;
 
 @Service
 public class JobTrainingNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private JobTrainingNoticeRepository jobTrainingNoticeRepository;
 
-    public PaginationDTO<JobTrainingNoticeDTO> getJobTrainingNotices(int page, int size) {
+    public JobTrainingNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    public PaginationDTO<JobTrainingNoticeDTO> getJobTrainingNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
         Page<JobTrainingNotice> resultPage = jobTrainingNoticeRepository.findAll(pageable);
 
-        List<JobTrainingNoticeDTO> dtoList = resultPage.stream()
-                .map(JobTrainingNoticeDTO::fromEntity)
-                .collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
 
+//        List<JobTrainingNoticeDTO> dtoList = resultPage.stream()
+//                .map(JobTrainingNoticeDTO::fromEntity)
+//                .collect(Collectors.toList());
+        List<JobTrainingNoticeDTO> dtoList = resultPage.stream()
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return JobTrainingNoticeDTO.builder()
+                            .company(notice.getCompany())
+                            .year(notice.getYear())
+                            .semester(notice.getSemester())
+                            .period(notice.getPeriod())
+                            .major(notice.getMajor())
+                            .recrutingNum(notice.getRecrutingNum())
+                            .deadline(notice.getDeadline())
+                            .jobName(notice.getJobName())
+                            .marked(isMarked)
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
+                .collect(Collectors.toList());
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
@@ -2,22 +2,29 @@ package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.LibraryNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.TeachingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.LibraryNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.LibraryNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 public class LibraryNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private LibraryNoticeRepository libraryNoticeRepository;
+
+    public LibraryNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
 
 //    public List<LibraryNoticeDTO> getAllLibraryNotices() {
 //        return libraryNoticeRepository.findAll().stream().map(notice -> new LibraryNoticeDTO(
@@ -25,14 +32,31 @@ public class LibraryNoticeService {
 //        )).collect(Collectors.toList());
 //    }
 
-    public PaginationDTO<LibraryNoticeDTO> getImportantNotices(int page, int size) {
+    public PaginationDTO<LibraryNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<LibraryNotice> resultPage = libraryNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<LibraryNotice> resultPage = libraryNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<LibraryNoticeDTO> dtoList = resultPage.stream()
+//                .map(LibraryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<LibraryNoticeDTO> dtoList = resultPage.stream()
-                .map(LibraryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return LibraryNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .campus(notice.getCampus())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
-
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
@@ -17,8 +17,8 @@ public class NormalNoticeService {
         this.normalNoticeRepository = normalNoticeRepository;
     }
 
-    public List<NormalNoticeDTO> getAllNormalNotices(boolean isImportant) throws NotFoundException {
-        List<NormalNotice> notices = normalNoticeRepository.findByIsImportant(isImportant);
+    public List<NormalNoticeDTO> getAllNormalNotices(boolean important) throws NotFoundException {
+        List<NormalNotice> notices = normalNoticeRepository.findByImportant(important);
         if (notices == null || notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.NormalNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.NormalNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NormalNoticeService {
+    private final NormalNoticeRepository normalNoticeRepository;
+
+    public NormalNoticeService(NormalNoticeRepository normalNoticeRepository) {
+        this.normalNoticeRepository = normalNoticeRepository;
+    }
+
+    public List<NormalNoticeDTO> getAllNormalNotices(boolean isImportant) throws NotFoundException {
+        List<NormalNotice> notices = normalNoticeRepository.findByIsImportant(isImportant);
+        if (notices == null || notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new NormalNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl(), notice.isImportant()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
@@ -3,6 +3,7 @@ package depth.mvp.thinkerbell.domain.notice.service;
 import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.NormalNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.NormalNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +12,33 @@ import java.util.stream.Collectors;
 
 @Service
 public class NormalNoticeService {
+    private final BookmarkService bookmarkService;
     private final NormalNoticeRepository normalNoticeRepository;
 
-    public NormalNoticeService(NormalNoticeRepository normalNoticeRepository) {
+    public NormalNoticeService(BookmarkService bookmarkService, NormalNoticeRepository normalNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.normalNoticeRepository = normalNoticeRepository;
     }
 
-    public List<NormalNoticeDTO> getAllNormalNotices(boolean important) throws NotFoundException {
+    public List<NormalNoticeDTO> getAllNormalNotices(boolean important, String ssaid) throws NotFoundException {
         List<NormalNotice> notices = normalNoticeRepository.findByImportant(important);
         if (notices == null || notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new NormalNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl(), notice.isImportant()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return NormalNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .important(notice.isImportant())
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/RevisionNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/RevisionNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.RevisionNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.RevisionNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.RevisionNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class RevisionNoticeService {
+    private final RevisionNoticeRepository revisionNoticeRepository;
+
+    public RevisionNoticeService(RevisionNoticeRepository revisionNoticeRepository) {
+        this.revisionNoticeRepository = revisionNoticeRepository;
+    }
+
+    public List<RevisionNoticeDTO> getAllRevisionNotices() throws NotFoundException {
+        List<RevisionNotice> notices = revisionNoticeRepository.findAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new RevisionNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/RevisionNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/RevisionNoticeService.java
@@ -1,8 +1,10 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.RevisionNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.RevisionNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.RevisionNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +13,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class RevisionNoticeService {
+    private final BookmarkService bookmarkService;
     private final RevisionNoticeRepository revisionNoticeRepository;
 
-    public RevisionNoticeService(RevisionNoticeRepository revisionNoticeRepository) {
+    public RevisionNoticeService(BookmarkService bookmarkService, RevisionNoticeRepository revisionNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.revisionNoticeRepository = revisionNoticeRepository;
     }
 
-    public List<RevisionNoticeDTO> getAllRevisionNotices() throws NotFoundException {
+    public List<RevisionNoticeDTO> getAllRevisionNotices(String ssaid) throws NotFoundException {
         List<RevisionNotice> notices = revisionNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new RevisionNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return RevisionNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/SafetyNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/SafetyNoticeService.java
@@ -1,8 +1,12 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.SafetyNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.SafetyNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.SafetyNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +15,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class SafetyNoticeService {
+    private final BookmarkService bookmarkService;
     private final SafetyNoticeRepository safetyNoticeRepository;
 
-    public SafetyNoticeService(SafetyNoticeRepository safetyNoticeRepository) {
+    public SafetyNoticeService(BookmarkService bookmarkService, SafetyNoticeRepository safetyNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.safetyNoticeRepository = safetyNoticeRepository;
     }
 
-    public List<SafetyNoticeDTO> getAllSafetyNotices() throws NotFoundException {
+    public List<SafetyNoticeDTO> getAllSafetyNotices(String ssaid) throws NotFoundException {
         List<SafetyNotice> notices = safetyNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new SafetyNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return SafetyNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/SafetyNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/SafetyNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.SafetyNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.SafetyNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.SafetyNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class SafetyNoticeService {
+    private final SafetyNoticeRepository safetyNoticeRepository;
+
+    public SafetyNoticeService(SafetyNoticeRepository safetyNoticeRepository) {
+        this.safetyNoticeRepository = safetyNoticeRepository;
+    }
+
+    public List<SafetyNoticeDTO> getAllSafetyNotices() throws NotFoundException {
+        List<SafetyNotice> notices = safetyNoticeRepository.findAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new SafetyNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScheduleParser.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScheduleParser.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 
 public class ScheduleParser {
 
-    private static final Pattern DATE_PATTERN = Pattern.compile("\\.(\\d{2})\\s(\\d{2})\\s~\\s\\.(\\d{2})\\s(\\d{2})");
+    private static final Pattern DATE_PATTERN = Pattern.compile("\\.(\\d{2})\\s\\.(\\d{2})\\s~\\s\\.(\\d{2})\\s\\.(\\d{2})");
 
     public static LocalDate[] parseDate(String dateRange) {
         Matcher matcher = DATE_PATTERN.matcher(dateRange);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScholarshipNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScholarshipNoticeService.java
@@ -3,6 +3,7 @@ package depth.mvp.thinkerbell.domain.notice.service;
 import depth.mvp.thinkerbell.domain.notice.dto.ScholarshipNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.ScholarshipNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.ScholarshipNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +12,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class ScholarshipNoticeService {
+    private final BookmarkService bookmarkService;
     private final ScholarshipNoticeRepository scholarshipNoticeRepository;
 
-    public ScholarshipNoticeService(ScholarshipNoticeRepository scholarshipNoticeRepository) {
+    public ScholarshipNoticeService(BookmarkService bookmarkService, ScholarshipNoticeRepository scholarshipNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.scholarshipNoticeRepository = scholarshipNoticeRepository;
     }
 
-    public List<ScholarshipNoticeDTO> getAllScholarshipNotices() throws NotFoundException {
+    public List<ScholarshipNoticeDTO> getAllScholarshipNotices(String ssaid) throws NotFoundException {
         List<ScholarshipNotice> notices = scholarshipNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new ScholarshipNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return ScholarshipNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScholarshipNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScholarshipNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.ScholarshipNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.ScholarshipNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.ScholarshipNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ScholarshipNoticeService {
+    private final ScholarshipNoticeRepository scholarshipNoticeRepository;
+
+    public ScholarshipNoticeService(ScholarshipNoticeRepository scholarshipNoticeRepository) {
+        this.scholarshipNoticeRepository = scholarshipNoticeRepository;
+    }
+
+    public List<ScholarshipNoticeDTO> getAllScholarshipNotices() throws NotFoundException {
+        List<ScholarshipNotice> notices = scholarshipNoticeRepository.findAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new ScholarshipNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/StudentActsNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/StudentActsNoticeService.java
@@ -1,8 +1,10 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.StudentActsNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.StudentActsNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.StudentActsNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +13,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class StudentActsNoticeService {
+    private final BookmarkService bookmarkService;
     private final StudentActsNoticeRepository studentActsNoticeRepository;
 
-    public StudentActsNoticeService(StudentActsNoticeRepository studentActsNoticeRepository) {
+    public StudentActsNoticeService(BookmarkService bookmarkService, StudentActsNoticeRepository studentActsNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.studentActsNoticeRepository = studentActsNoticeRepository;
     }
 
-    public List<StudentActsNoticeDTO> getAllStudentActsNotices() throws NotFoundException {
+    public List<StudentActsNoticeDTO> getAllStudentActsNotices(String ssaid) throws NotFoundException {
         List<StudentActsNotice> notices = studentActsNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new StudentActsNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return StudentActsNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/StudentActsNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/StudentActsNoticeService.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.notice.service;
+
+import depth.mvp.thinkerbell.domain.notice.dto.StudentActsNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.entity.StudentActsNotice;
+import depth.mvp.thinkerbell.domain.notice.repository.StudentActsNoticeRepository;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class StudentActsNoticeService {
+    private final StudentActsNoticeRepository studentActsNoticeRepository;
+
+    public StudentActsNoticeService(StudentActsNoticeRepository studentActsNoticeRepository) {
+        this.studentActsNoticeRepository = studentActsNoticeRepository;
+    }
+
+    public List<StudentActsNoticeDTO> getAllStudentActsNotices() throws NotFoundException {
+        List<StudentActsNotice> notices = studentActsNoticeRepository.findAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("저장된 공지사항이 없습니다.");
+        }
+        return notices.stream().map(notice -> new StudentActsNoticeDTO(
+                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
@@ -1,9 +1,11 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.TeachingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.TeachingNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.TeachingNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,18 +17,38 @@ import java.util.stream.Collectors;
 
 @Service
 public class TeachingNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private TeachingNoticeRepository teachingNoticeRepository;
 
-    public PaginationDTO<TeachingNoticeDTO> getImportantNotices(int page, int size) {
+    public TeachingNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    public PaginationDTO<TeachingNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<TeachingNotice> resultPage = teachingNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<TeachingNotice> resultPage = teachingNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<TeachingNoticeDTO> dtoList = resultPage.stream()
+//                .map(TeachingNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<TeachingNoticeDTO> dtoList = resultPage.stream()
-                .map(TeachingNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return TeachingNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
-
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
@@ -1,0 +1,78 @@
+package depth.mvp.thinkerbell.domain.user.controller;
+
+import depth.mvp.thinkerbell.domain.user.dto.AlarmDto;
+import depth.mvp.thinkerbell.domain.user.service.AlarmService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/alarm")
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @Operation(summary = "미확인 알림 여부 확인", description = "사용자 SSAID와 키워드로 미확인 알림이 있는지 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/check")
+    public ApiResult<Boolean> checkUnviewedAlarm(@RequestParam String SSAID, @RequestParam String keyword) {
+        try {
+            boolean hasUnviewed = alarmService.hasUnviewedAlarm(SSAID, keyword);
+            return ApiResult.ok(hasUnviewed);
+        } catch (IllegalArgumentException e){
+            return ApiResult.withError(ErrorCode.INVALID_INPUT_VALUE);
+        } catch (RuntimeException e){
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "알람 읽음 처리", description = "특정 알람을 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/mark-viewed")
+    public ApiResult<String> markAsViewed(@RequestParam Long alarmId) {
+        try {
+            alarmService.markAsViewed(alarmId);
+            return ApiResult.ok("알림이 성공적으로 읽음 처리되었습니다.");
+        } catch (IllegalArgumentException e){
+            return ApiResult.withError(ErrorCode.INVALID_INPUT_VALUE, "잘못된 입력 값");
+        } catch (RuntimeException e){
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, "서버 오류 발생");
+        }
+    }
+
+    @Operation(summary = "알람 조회", description = "키워드와 사용자 SSAID로 알람을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/get")
+    public ApiResult<List<AlarmDto>> getAlarm(@RequestParam String SSAID, @RequestParam String keyword) {
+        try {
+            List<AlarmDto> alarms = alarmService.getAlarms(SSAID, keyword);
+            return ApiResult.ok(alarms);
+        } catch (IllegalArgumentException e){
+            return ApiResult.withError(ErrorCode.INVALID_INPUT_VALUE, null);
+        } catch (RuntimeException e){
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
@@ -1,0 +1,54 @@
+package depth.mvp.thinkerbell.domain.user.controller;
+
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/bookmark")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @Operation(summary = "공지사항 즐겨찾기 설정", description = "공지사항을 즐겨찾기합니다. (false -> true)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 저장됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @PostMapping("")
+    public ApiResult<?> saveBookmark(@RequestParam("category") String category,
+                                     @RequestParam("notice-id") Long noticeId,
+                                     @RequestParam("user-id") Long userId) {
+        try {
+            bookmarkService.saveBookmark(category, noticeId, userId);
+            return ApiResult.ok("성공적으로 저장됨");
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+
+    @Operation(summary = "공지사항 즐겨찾기 취소", description = "공지사항을 즐겨찾기 취소합니다. (true -> false)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 삭제됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @DeleteMapping("")
+    public ApiResult<?> deleteBookmark(@RequestParam("category") String category,
+                                     @RequestParam("notice-id") Long noticeId,
+                                     @RequestParam("user-id") Long userId) {
+        try {
+            bookmarkService.deleteBookmark(category, noticeId, userId);
+            return ApiResult.ok("성공적으로 삭제됨");
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
@@ -25,9 +25,9 @@ public class BookmarkController {
     @PostMapping("")
     public ApiResult<?> saveBookmark(@RequestParam("category") String category,
                                      @RequestParam("notice-id") Long noticeId,
-                                     @RequestParam("user-id") Long userId) {
+                                     @RequestParam("ssaid") String ssaid) {
         try {
-            bookmarkService.saveBookmark(category, noticeId, userId);
+            bookmarkService.saveBookmark(category, noticeId, ssaid);
             return ApiResult.ok("성공적으로 저장됨");
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
@@ -43,9 +43,9 @@ public class BookmarkController {
     @DeleteMapping("")
     public ApiResult<?> deleteBookmark(@RequestParam("category") String category,
                                      @RequestParam("notice-id") Long noticeId,
-                                     @RequestParam("user-id") Long userId) {
+                                     @RequestParam("ssaid") String ssaid) {
         try {
-            bookmarkService.deleteBookmark(category, noticeId, userId);
+            bookmarkService.deleteBookmark(category, noticeId, ssaid);
             return ApiResult.ok("성공적으로 삭제됨");
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/dto/AlarmDto.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/dto/AlarmDto.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AlarmDto {
+
+    private Long id;
+    private String title;
+    private String noticeType;
+    private Boolean isViewed;
+    private String Url;
+    private String pubDate;
+
+
+    @Builder
+    public AlarmDto(Long id, String title, String noticeType, Boolean isViewed, String Url, String pubDate) {
+        this.id = id;
+        this.title = title;
+        this.noticeType = noticeType;
+        this.isViewed = isViewed;
+        this.Url = Url;
+        this.pubDate = pubDate;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Alarm.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Alarm.java
@@ -1,14 +1,12 @@
 package depth.mvp.thinkerbell.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
+@Setter
 @Table(name = "Alarm")
 public class Alarm {
 
@@ -17,15 +15,20 @@ public class Alarm {
     private Long id;
     private Long noticeID;
     private String noticeType;
+    private String title;
+    private String keyword;
+    private Boolean isViewed = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @Builder
-    public Alarm(Long noticeID, String noticeType, User user) {
+    public Alarm(Long noticeID, String noticeType, User user, String title, String keyword) {
         this.noticeID = noticeID;
         this.noticeType = noticeType;
         this.user = user;
+        this.title = title;
+        this.keyword = keyword;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Bookmark.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Bookmark.java
@@ -16,16 +16,16 @@ public class Bookmark {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long noticeID;
-    private String noticeType;
+    private String category;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @Builder
-    public Bookmark(Long noticeID, String noticeType, User user) {
+    public Bookmark(Long noticeID, String category, User user) {
         this.noticeID = noticeID;
-        this.noticeType = noticeType;
+        this.category = category;
         this.user = user;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/repository/AlarmRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/repository/AlarmRepository.java
@@ -1,0 +1,13 @@
+package depth.mvp.thinkerbell.domain.user.repository;
+
+import depth.mvp.thinkerbell.domain.user.entity.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+    boolean existsByUserIdAndKeywordAndIsViewedFalse(Long userId, String keyword);
+
+    List<Alarm> findALLByUserIdAndKeyword (Long userId, String keyword);
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/repository/BookmarkRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/repository/BookmarkRepository.java
@@ -1,0 +1,14 @@
+package depth.mvp.thinkerbell.domain.user.repository;
+
+import depth.mvp.thinkerbell.domain.user.entity.Bookmark;
+import depth.mvp.thinkerbell.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    List<Bookmark> findByUserAndCategory(User user, String category);
+    Bookmark findByCategoryAndNoticeIDAndUser(String category, Long NoticeId, User user);
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
@@ -1,0 +1,203 @@
+package depth.mvp.thinkerbell.domain.user.service;
+
+import depth.mvp.thinkerbell.domain.common.service.CategoryService;
+import depth.mvp.thinkerbell.domain.notice.entity.AllNoticesView;
+import depth.mvp.thinkerbell.domain.notice.entity.CrawlingNum;
+import depth.mvp.thinkerbell.domain.notice.repository.AllNoticeViewRepository;
+import depth.mvp.thinkerbell.domain.notice.repository.CrawlingNumRepository;
+import depth.mvp.thinkerbell.domain.user.dto.AlarmDto;
+import depth.mvp.thinkerbell.domain.user.entity.Alarm;
+import depth.mvp.thinkerbell.domain.user.entity.Keyword;
+import depth.mvp.thinkerbell.domain.user.entity.User;
+import depth.mvp.thinkerbell.domain.user.repository.AlarmRepository;
+import depth.mvp.thinkerbell.domain.user.repository.KeywordRepository;
+import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlarmService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final AllNoticeViewRepository allNoticeViewRepository;
+    private final KeywordRepository keywordRepository;
+    private final CrawlingNumRepository crawlingNumRepository;
+    private final AlarmRepository alarmRepository;
+    private final UserRepository userRepository;
+    private final FCMService fcmService;
+    private final CategoryService categoryService;
+
+    //전체 공지사항이 있는 뷰에서 키워드에 일치하는 공지를 찾아서 알람 테이블에 저장하는 기능
+    //이때 최신으로 업데이트된 공지사항만 탐색한다.
+    //알람 테이블에 저장되는 것들은 바로 fcm 알림까지 전송된다.
+    @Scheduled(cron = "0 0 10-22/3 * * ?")
+    public void updateNoticeAndMatchKeyword(){
+        List<CrawlingNum> crawlingNums;
+
+        try {
+            crawlingNums = crawlingNumRepository.findAll();
+        } catch (Exception e) {
+            throw new RuntimeException("크롤링 번호 레코드를 가져오는 동안 오류가 발생했습니다.", e);
+        }
+
+        for (CrawlingNum crawlingNum : crawlingNums) {
+            List<AllNoticesView> allNoticesViews;
+
+            try {
+                allNoticesViews = allNoticeViewRepository.findNewNoticesByCategory(crawlingNum.getNoticeType(), crawlingNum.getNoticeID());
+
+            } catch (Exception e) {
+                throw new RuntimeException(crawlingNum.getNoticeType() + "의 새로운 공지사항을 가져오는 중 오류가 발생했습니다.", e);
+            }
+
+            for (Keyword keyword : keywordRepository.findAll()) {
+                for (AllNoticesView notice : allNoticesViews) {
+                    String titleWithoutSpace = notice.getTitle().replace(" ", "");
+
+                    if (titleWithoutSpace.contains(keyword.getKeyword())) {
+                        try{
+                            Alarm alarm = new Alarm(notice.getId(), notice.getTableName(), keyword.getUser(), notice.getTitle(), keyword.getKeyword());
+
+                            alarmRepository.save(alarm);
+
+                            fcmService.sendFCMMessage(alarm, keyword.getKeyword());
+                        } catch (Exception e) {
+                            throw new RuntimeException("유저 알림을 저장하거나, fcm 알림을 보내는 도중 오류가 발생했습니다.", e);
+                        }
+                    }
+                }
+            }
+
+            //크롤링번호 최신화
+            try {
+                Long newMaxID = allNoticeViewRepository.findMaxIdByCategory(crawlingNum.getNoticeType());
+
+                Optional<CrawlingNum> existingCrawlingNumOpt = crawlingNumRepository.findByNoticeType(crawlingNum.getNoticeType());
+
+                if (existingCrawlingNumOpt.isPresent()) {
+                    // 존재하는 경우 업데이트
+                    CrawlingNum existingCrawlingNum = existingCrawlingNumOpt.get();
+                    existingCrawlingNum.setNoticeID(newMaxID);
+                    crawlingNumRepository.save(existingCrawlingNum);
+                } else {
+                    // 존재하지 않는 경우 새로 저장
+                    CrawlingNum newCrawlingNum = CrawlingNum.builder()
+                            .noticeID(newMaxID)
+                            .noticeType(crawlingNum.getNoticeType())
+                            .build();
+                    crawlingNumRepository.save(newCrawlingNum);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(crawlingNum.getNoticeType() + "의 크롤링 번호를 업데이트 하는 도중 오류가 발생했습니다.", e);
+            }
+        }
+    }
+
+    //보지 않은 알림이 있으면 true, 없으면 false
+    public boolean hasUnviewedAlarm(String SSAID, String keyword){
+        Optional<User> userOpt = userRepository.findBySsaid(SSAID);
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+
+            return alarmRepository.existsByUserIdAndKeywordAndIsViewedFalse(user.getId(), keyword);
+        }
+        return false;
+    }
+
+    //안본거 본걸로 바꾸기
+    public void markAsViewed(Long alarmID){
+        Alarm alarm = alarmRepository.findById(alarmID)
+                .orElseThrow(() -> new EntityNotFoundException("해당 id의 알림이 없습니다."));
+        alarm.setIsViewed(true);
+    }
+
+    //알림 키워드, 사용자 기반 조회
+    public List<AlarmDto> getAlarms(String SSAID, String keyword){
+        Optional<User> userOpt = userRepository.findBySsaid(SSAID);
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+
+            List<Alarm> alarms = alarmRepository.findALLByUserIdAndKeyword(user.getId(), keyword);
+            List<AlarmDto> alarmDtos = new ArrayList<>();
+
+            for (Alarm alarm : alarms) {
+                if (Objects.equals(alarm.getNoticeType(), "job_training_notice")){
+                    String pubDate = getNoticeDetail(alarm.getNoticeType(), alarm.getNoticeID());
+
+                    AlarmDto alarmDto = AlarmDto.builder()
+                            .id(alarm.getId())
+                            .title(alarm.getTitle())
+                            .noticeType(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .isViewed(alarm.getIsViewed())
+                            .Url(null)
+                            .pubDate(pubDate)
+                            .build();
+
+                    alarmDtos.add(alarmDto);
+                } else {
+                    Map<String, Object> noticeDetails = getNoticeDetails(alarm.getNoticeType(), alarm.getNoticeID());
+
+                    String url = (String) noticeDetails.get("url");
+                    String pubDate = (String) noticeDetails.get("pubDate");
+
+                    AlarmDto alarmDto = AlarmDto.builder()
+                            .id(alarm.getId())
+                            .title(alarm.getTitle())
+                            .noticeType(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .isViewed(alarm.getIsViewed())
+                            .Url(url)
+                            .pubDate(pubDate)
+                            .build();
+
+                    alarmDtos.add(alarmDto);
+                }
+            }
+
+            return alarmDtos;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private Map<String, Object> getNoticeDetails(String tableName, Long noticeID) {
+        String sql = "SELECT url, DATE_FORMAT(pub_date, '%Y-%m-%d') as pubDate FROM " + tableName + " WHERE id = :noticeID";
+
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("noticeID", noticeID);
+
+        List<Object[]> results = query.getResultList();
+
+        if (!results.isEmpty()) {
+            Object[] row = results.get(0);
+            Map<String, Object> resultMap = new HashMap<>();
+            resultMap.put("url", row[0]);
+            resultMap.put("pubDate", row[1]);
+            return resultMap;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    public String getNoticeDetail(String tableName, Long noticeID) {
+        String sql = "SELECT semester FROM " + tableName + " WHERE id = :noticeID";
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("noticeID", noticeID);
+
+        Object result = query.getSingleResult();
+        return result != null ? result.toString() : null;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
@@ -1,0 +1,45 @@
+package depth.mvp.thinkerbell.domain.user.service;
+
+import depth.mvp.thinkerbell.domain.user.entity.Bookmark;
+import depth.mvp.thinkerbell.domain.user.entity.User;
+import depth.mvp.thinkerbell.domain.user.repository.BookmarkRepository;
+import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+
+    public Bookmark saveBookmark(String category, Long noticeId, Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+        if (bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user) != null){
+            throw new NotFoundException("이미 즐겨찾기한 공지입니다.");
+        }else {
+            return bookmarkRepository.save(Bookmark.builder()
+                    .category(category)
+                    .noticeID(noticeId)
+                    .user(user)
+                    .build());
+        }
+    }
+
+    public void deleteBookmark(String category, Long noticeId, Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+        Bookmark bookmark = bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user);
+        if (bookmark == null) {
+            new NotFoundException("즐겨찾기 내역을 찾을 수 없습니다.");
+        }
+        bookmarkRepository.deleteById(bookmark.getId());
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -17,9 +19,17 @@ public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final UserRepository userRepository;
 
-    public Bookmark saveBookmark(String category, Long noticeId, Long userId) {
+    public List<Long> getBookmark(String ssaid, String category) {
+        User user = userRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
 
-        User user = userRepository.findById(userId)
+        return bookmarkRepository.findByUserAndCategory(user, category)
+                .stream()
+                .map(Bookmark::getNoticeID).toList();
+    }
+    public Bookmark saveBookmark(String category, Long noticeId, String ssaid) {
+
+        User user = userRepository.findBySsaid(ssaid)
                 .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
         if (bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user) != null){
             throw new NotFoundException("이미 즐겨찾기한 공지입니다.");
@@ -31,10 +41,9 @@ public class BookmarkService {
                     .build());
         }
     }
+    public void deleteBookmark(String category, Long noticeId, String ssaid) {
 
-    public void deleteBookmark(String category, Long noticeId, Long userId) {
-
-        User user = userRepository.findById(userId)
+        User user = userRepository.findBySsaid(ssaid)
                 .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
         Bookmark bookmark = bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user);
         if (bookmark == null) {

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/FCMService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/FCMService.java
@@ -1,0 +1,46 @@
+package depth.mvp.thinkerbell.domain.user.service;
+
+import com.google.firebase.messaging.*;
+import depth.mvp.thinkerbell.domain.common.service.CategoryService;
+import depth.mvp.thinkerbell.domain.user.entity.Alarm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FCMService {
+
+    private final CategoryService categoryService;
+
+    public void sendFCMMessage(Alarm alarm, String keyword) {
+        try{
+            String category = categoryService.getCategoryNameInKorean(alarm.getNoticeType());
+            String cutTitle = cutTitle(alarm.getTitle(), 30);
+
+            String messageBody = String.format("‘띵~🔔 %s와(과) 관련한 공지가 올라왔어요!’\n\n[%s] %s",
+                    keyword, category, cutTitle);
+
+            Message message = Message.builder()
+                    .setAndroidConfig(AndroidConfig.builder()
+                            .setNotification(AndroidNotification.builder()
+                                    .setTitle("띵커벨")
+                                    .setBody(messageBody)
+                                    .build())
+                            .build())
+                    .setToken(alarm.getUser().getFcmToken())
+                    .build();
+
+            String responce = FirebaseMessaging.getInstance().send(message);
+            System.out.println("전송 성공" + responce);
+        } catch (Exception e){
+            throw new RuntimeException("FCM 알림을 전송하는 동안 오류가 발생했습니다.",e);
+        }
+    }
+
+    private String cutTitle(String title, int maxLength) {
+        if (title.length() > maxLength) {
+            return title.substring(0, maxLength - 1) + "…"; // 말줄임표 추가
+        }
+        return title;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/global/config/FirebaseConfig.java
+++ b/src/main/java/depth/mvp/thinkerbell/global/config/FirebaseConfig.java
@@ -1,0 +1,25 @@
+package depth.mvp.thinkerbell.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        FileInputStream serviceAccount = new FileInputStream("src/main/resources/firebase/neverland-thinkerbell-firebase-adminsdk-n4ik2-49baee872c.json");
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/resources/Categories.json
+++ b/src/main/resources/Categories.json
@@ -1,0 +1,15 @@
+{
+  "academic_notice": "학사 공지",
+  "bidding_notice": "입철 공지",
+  "career_notice": "진로/취업/창업 공지",
+  "dormitory_entry_notice": "기숙사 입/퇴사 공지",
+  "dormitory_notice": "기숙사 공지",
+  "event_notice": "행사 공지",
+  "job_training_notice": "현장 실습 지원 공지",
+  "library_notice": "도서관 공지",
+  "normal_notice": "일반 공지",
+  "revision_notice": "학칙개정 사전공고",
+  "scholarship_notice": "장학/학자금 공지",
+  "student_acts_notice": "학생활동 공지",
+  "teaching_notice": "교직 공지"
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- 스케쥴러를 넣어서 크롤링 시간 이후에 자동으로 알림 전송[O] 
- 카테고리(테이블 명) 한글 변환 기능 추가[O]
- 알림 키워드 별 조회 기능 및 필요 정보 DTO제공 [O]
- 읽지 않은 알림 조회 가능, 알림 읽음 처리 가능 [O]
- FCM 알림 형식 제작 [O]

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
오전 10시 부터 오후 11시까지 3시간 간격으로 새로 크롤링된 공지사항에 한하여 알림이 가도록 했습니다.
(아직 FCM Token을 못받아서 확인을 못했습니다. 추가 수정 있을 수 있습니다.)
알림 테이블에서 키워드 별로 미확인 알림 확인, 알림 읽음 처리, 키워드 별 알림 조회 기능 추가했습니다.
common/service에 카테고리 (테이블 명)을 한글로 바꿀 수 있는 로직 추가했습니다. (필요하시면 쓰시면 됩니다 ^^7)
JPA로는 여러 테이블 조회 및 다양한 작업에 제한이 있어서 SQL문 직접 작성하여 진행했습니다.
현재 저장되어 있는 데이터 기준으로 문제없이 작동 됩니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
https://adjh54.tistory.com/438