### PR TITLE
[FEATURE] 즐겨찾기 조회 기능 구현

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/AcademicNoticeController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,22 +17,24 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AcademicNoticeController {
 
-    private final AcademicNoticeService academicNoticeService;
-
     @Operation(summary = "명지대 학사 공지사항 조회", description = "명지대 학사 공지사항을 조회합니다. (https://www.mju.ac" +
-            ".kr/mjukr/257/subview.do) 중요 공지를 조회할 땐 인자로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
+            ".kr/mjukr/257/subview.do) 중요 공지를 조회할 땐 인자(important)로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/{important}")
-    public ApiResult<List<AcademicNoticeDTO>> getAllAcademicNotices(@PathVariable("important") boolean important) {
+    @GetMapping
+    public ApiResult<List<AcademicNoticeDTO>> getAllAcademicNotices(@RequestParam(value = "important", required = false,
+            defaultValue = "false") boolean important,
+                                                                    @RequestParam("ssaid") String ssaid) {
         try {
-            List<AcademicNoticeDTO> notices = academicNoticeService.getAllAcademicNotices(important);
+            List<AcademicNoticeDTO> notices = academicNoticeService.getAllAcademicNotices(important, ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
         }
     }
+
+    private final AcademicNoticeService academicNoticeService;
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/BiddingNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/BiddingNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class BiddingNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<BiddingNoticeDTO>> getAllBiddingNotices() {
+    public ApiResult<List<BiddingNoticeDTO>> getAllBiddingNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<BiddingNoticeDTO> notices = biddingNoticeService.getAllBiddingNotices();
+            List<BiddingNoticeDTO> notices = biddingNoticeService.getAllBiddingNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/CareerNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/CareerNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class CareerNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<CareerNoticeDTO>> getAllCareerNotices() {
+    public ApiResult<List<CareerNoticeDTO>> getAllCareerNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<CareerNoticeDTO> notices = careerNoticeService.getAllCareerNotices();
+            List<CareerNoticeDTO> notices = careerNoticeService.getAllCareerNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/DormitoryController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/DormitoryController.java
@@ -33,9 +33,10 @@ public class DormitoryController {
     @GetMapping("/notices")
     public ApiResult<PaginationDTO<DormitoryNoticeDTO>> getImportantNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<DormitoryNoticeDTO> paginationDTO = dormitoryNoticeService.getImportantNotices(page, size);
+            PaginationDTO<DormitoryNoticeDTO> paginationDTO = dormitoryNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
@@ -51,9 +52,11 @@ public class DormitoryController {
     @GetMapping("/entry-notices")
     public ApiResult<PaginationDTO<DormitoryEntryNoticeDTO>> getImportantEntryNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<DormitoryEntryNoticeDTO> paginationDTO = dormitoryEntryNoticeService.getImportantNotices(page, size);
+            PaginationDTO<DormitoryEntryNoticeDTO> paginationDTO =
+                    dormitoryEntryNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/EventNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/EventNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class EventNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<EventNoticeDTO>> getAllEventNotices() {
+    public ApiResult<List<EventNoticeDTO>> getAllEventNotices(@RequestParam("ssaid")String ssaid) {
         try {
-            List<EventNoticeDTO> notices = eventNoticeService.getAllEventNotices();
+            List<EventNoticeDTO> notices = eventNoticeService.getAllEventNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/JobTrainingController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/JobTrainingController.java
@@ -2,6 +2,7 @@ package depth.mvp.thinkerbell.domain.notice.controller;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.JobTrainingNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.service.DormitoryNoticeService;
 import depth.mvp.thinkerbell.domain.notice.service.JobTrainingNoticeService;
 import depth.mvp.thinkerbell.global.dto.ApiResult;
 import depth.mvp.thinkerbell.global.exception.ErrorCode;
@@ -31,9 +32,11 @@ public class JobTrainingController {
     @GetMapping
     public ApiResult<PaginationDTO<JobTrainingNoticeDTO>> getJobTrainingNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<JobTrainingNoticeDTO> paginationDTO = jobTrainingNoticeService.getJobTrainingNotices(page, size);
+            PaginationDTO<JobTrainingNoticeDTO> paginationDTO = jobTrainingNoticeService.getJobTrainingNotices(page,
+                    size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/LibraryController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/LibraryController.java
@@ -33,9 +33,10 @@ public class LibraryController {
     @GetMapping
     public ApiResult<PaginationDTO<LibraryNoticeDTO>> getImportantLibraryNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<LibraryNoticeDTO> paginationDTO = libraryNoticeService.getImportantNotices(page, size);
+            PaginationDTO<LibraryNoticeDTO> paginationDTO = libraryNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/NormalNoticeController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,16 +20,18 @@ public class NormalNoticeController {
     private final NormalNoticeService normalNoticeService;
 
     @Operation(summary = "명지대 일반 공지사항 조회", description = "명지대 일반 공지사항을 조회합니다. (https://www.mju.ac" +
-            ".kr/mjukr/255/subview.do) 중요 공지를 조회할 땐 인자로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
+            ".kr/mjukr/255/subview.do) 중요 공지를 조회할 땐 인자(important)로 true, 그 외 공지를 조회할 땐 false를 전달해주세요.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 조회됨"),
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/{important}")
-    public ApiResult<List<NormalNoticeDTO>> getAllNormalNotices(@PathVariable("important") boolean important) {
+    @GetMapping
+    public ApiResult<List<NormalNoticeDTO>> getAllNormalNotices(@RequestParam(value = "important", required = false,
+                                                                              defaultValue = "false") boolean important,
+                                                                @RequestParam("ssaid") String ssaid) {
         try {
-            List<NormalNoticeDTO> notices = normalNoticeService.getAllNormalNotices(important);
+            List<NormalNoticeDTO> notices = normalNoticeService.getAllNormalNotices(important, ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/RevisionNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/RevisionNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class RevisionNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<RevisionNoticeDTO>> getAllRevisionNotices() {
+    public ApiResult<List<RevisionNoticeDTO>> getAllRevisionNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<RevisionNoticeDTO> notices = revisionNoticeService.getAllRevisionNotices();
+            List<RevisionNoticeDTO> notices = revisionNoticeService.getAllRevisionNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/SafetyNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/SafetyNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class SafetyNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<SafetyNoticeDTO>> getAllSafetyNotices() {
+    public ApiResult<List<SafetyNoticeDTO>> getAllSafetyNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<SafetyNoticeDTO> notices = safetyNoticeService.getAllSafetyNotices();
+            List<SafetyNoticeDTO> notices = safetyNoticeService.getAllSafetyNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/ScholarshipNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/ScholarshipNoticeController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -31,9 +32,9 @@ public class ScholarshipNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<ScholarshipNoticeDTO>> getAllScholarshipNotices() {
+    public ApiResult<List<ScholarshipNoticeDTO>> getAllScholarshipNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<ScholarshipNoticeDTO> notices = scholarshipNoticeService.getAllScholarshipNotices();
+            List<ScholarshipNoticeDTO> notices = scholarshipNoticeService.getAllScholarshipNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/StudentActsNoticeController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/StudentActsNoticeController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -29,9 +30,9 @@ public class StudentActsNoticeController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping
-    public ApiResult<List<StudentActsNoticeDTO>> getAllStudentActsNotices() {
+    public ApiResult<List<StudentActsNoticeDTO>> getAllStudentActsNotices(@RequestParam("ssaid") String ssaid) {
         try {
-            List<StudentActsNoticeDTO> notices = studentActsNoticeService.getAllStudentActsNotices();
+            List<StudentActsNoticeDTO> notices = studentActsNoticeService.getAllStudentActsNotices(ssaid);
             return ApiResult.ok(notices);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/controller/TeachingController.java
@@ -32,9 +32,10 @@ public class TeachingController {
     @GetMapping
     public ApiResult<PaginationDTO<TeachingNoticeDTO>> getImportantTeachingNotices(
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("ssaid") String ssaid) {
         try {
-            PaginationDTO<TeachingNoticeDTO> paginationDTO = teachingNoticeService.getImportantNotices(page, size);
+            PaginationDTO<TeachingNoticeDTO> paginationDTO = teachingNoticeService.getImportantNotices(page, size, ssaid);
             return ApiResult.ok(paginationDTO);
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
@@ -13,14 +13,16 @@ public class AcademicNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     private boolean important;
 
     @Builder
-    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean important) {
+    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
         this.important = important;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/AcademicNoticeDTO.java
@@ -1,13 +1,15 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class AcademicNoticeDTO {
     private Long id;
     private LocalDate pubDate;
@@ -16,13 +18,4 @@ public class AcademicNoticeDTO {
     private boolean marked;
     private boolean important;
 
-    @Builder
-    public AcademicNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-        this.important = important;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
@@ -1,13 +1,15 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class BiddingNoticeDTO {
     private Long id;
     private LocalDate pubDate;
@@ -15,12 +17,4 @@ public class BiddingNoticeDTO {
     private String url;
     private boolean marked;
 
-    @Builder
-    public BiddingNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/BiddingNoticeDTO.java
@@ -13,11 +13,14 @@ public class BiddingNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
+
     @Builder
-    public BiddingNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public BiddingNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
@@ -13,11 +13,13 @@ public class CareerNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public CareerNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public CareerNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/CareerNoticeDTO.java
@@ -1,25 +1,20 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class CareerNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public CareerNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
+
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryEntryNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryEntryNoticeDTO.java
@@ -2,29 +2,33 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryEntryNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class DormitoryEntryNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private boolean isImportant;
+    private boolean marked;
+    private boolean important;
     private String campus;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static DormitoryEntryNoticeDTO fromEntity(DormitoryEntryNotice notice) {
-        return new DormitoryEntryNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant(),
-                notice.getCampus()
-        );
-    }
+//    public static DormitoryEntryNoticeDTO fromEntity(DormitoryEntryNotice notice) {
+//        return new DormitoryEntryNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant(),
+//                notice.getCampus()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/DormitoryNoticeDTO.java
@@ -2,30 +2,33 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class DormitoryNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private boolean isImportant;
+    private boolean marked;
+    private boolean important;
     private String campus;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static DormitoryNoticeDTO fromEntity(DormitoryNotice notice) {
-        return new DormitoryNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant(),
-                notice.getCampus()
-        );
-    }
-
+//    public static DormitoryNoticeDTO fromEntity(DormitoryNotice notice) {
+//        return new DormitoryNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant(),
+//                notice.getCampus()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
@@ -1,25 +1,20 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class EventNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public EventNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
+
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/EventNoticeDTO.java
@@ -13,11 +13,13 @@ public class EventNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public EventNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public EventNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/JobTrainingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/JobTrainingNoticeDTO.java
@@ -2,10 +2,12 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.JobTrainingNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
+@Builder
 public class JobTrainingNoticeDTO {
     private String company;
     private String year;
@@ -15,18 +17,19 @@ public class JobTrainingNoticeDTO {
     private String recrutingNum;
     private String deadline;
     private String jobName;
+    private boolean marked;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static JobTrainingNoticeDTO fromEntity(JobTrainingNotice notice) {
-        return new JobTrainingNoticeDTO(
-                notice.getCompany(),
-                notice.getYear(),
-                notice.getSemester(),
-                notice.getPeriod(),
-                notice.getMajor(),
-                notice.getRecrutingNum(),
-                notice.getDeadline(),
-                notice.getJobName()
-        );
-    }
+//    public static JobTrainingNoticeDTO fromEntity(JobTrainingNotice notice) {
+//        return new JobTrainingNoticeDTO(
+//                notice.getCompany(),
+//                notice.getYear(),
+//                notice.getSemester(),
+//                notice.getPeriod(),
+//                notice.getMajor(),
+//                notice.getRecrutingNum(),
+//                notice.getDeadline(),
+//                notice.getJobName()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/LibraryNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/LibraryNoticeDTO.java
@@ -7,23 +7,25 @@ import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class LibraryNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private Boolean isImportant;
+    private boolean marked;
+    private Boolean important;
     private String campus;
 
     // 엔티티를 DTO로 변환하는 정적 메서드
-    public static LibraryNoticeDTO fromEntity(LibraryNotice notice) {
-        return new LibraryNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant(),
-                notice.getCampus()
-        );
-    }
+//    public static LibraryNoticeDTO fromEntity(LibraryNotice notice) {
+//        return new LibraryNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant(),
+//                notice.getCampus()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
@@ -13,14 +13,16 @@ public class NormalNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     private boolean important;
 
     @Builder
-    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean important) {
+    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
         this.important = important;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/NormalNoticeDTO.java
@@ -1,13 +1,15 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class NormalNoticeDTO {
     private Long id;
     private LocalDate pubDate;
@@ -16,13 +18,4 @@ public class NormalNoticeDTO {
     private boolean marked;
     private boolean important;
 
-    @Builder
-    public NormalNoticeDTO(Long id, LocalDate pubDate, String title, String url, boolean marked, boolean important) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-        this.important = important;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
@@ -13,11 +13,13 @@ public class RevisionNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public RevisionNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public RevisionNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/RevisionNoticeDTO.java
@@ -1,25 +1,20 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class RevisionNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public RevisionNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
+
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
@@ -1,25 +1,19 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class SafetyNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public SafetyNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/SafetyNoticeDTO.java
@@ -13,11 +13,13 @@ public class SafetyNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public SafetyNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public SafetyNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
@@ -1,25 +1,19 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class ScholarshipNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public ScholarshipNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/ScholarshipNoticeDTO.java
@@ -13,11 +13,13 @@ public class ScholarshipNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public ScholarshipNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public ScholarshipNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
@@ -13,11 +13,13 @@ public class StudentActsNoticeDTO {
     private LocalDate pubDate;
     private String title;
     private String url;
+    private boolean marked;
     @Builder
-    public StudentActsNoticeDTO(Long id, LocalDate pubDate, String title, String url) {
+    public StudentActsNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
         this.id = id;
         this.pubDate = pubDate;
         this.title = title;
         this.url = url;
+        this.marked = marked;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/StudentActsNoticeDTO.java
@@ -1,25 +1,19 @@
 package depth.mvp.thinkerbell.domain.notice.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class StudentActsNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
     private boolean marked;
-    @Builder
-    public StudentActsNoticeDTO(Long id, LocalDate pubDate, String title, boolean marked, String url) {
-        this.id = id;
-        this.pubDate = pubDate;
-        this.title = title;
-        this.url = url;
-        this.marked = marked;
-    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/TeachingNoticeDTO.java
@@ -2,26 +2,29 @@ package depth.mvp.thinkerbell.domain.notice.dto;
 
 import depth.mvp.thinkerbell.domain.notice.entity.TeachingNotice;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @AllArgsConstructor
 @Getter
+@Builder
 public class TeachingNoticeDTO {
     private Long id;
     private LocalDate pubDate;
     private String title;
     private String url;
-    private Boolean isImportant;
+    private Boolean important;
+    private boolean marked;
 
-    public static TeachingNoticeDTO fromEntity(TeachingNotice notice) {
-        return new TeachingNoticeDTO(
-                notice.getId(),
-                notice.getPubDate(),
-                notice.getTitle(),
-                notice.getUrl(),
-                notice.isImportant()
-        );
-    }
+//    public static TeachingNoticeDTO fromEntity(TeachingNotice notice) {
+//        return new TeachingNoticeDTO(
+//                notice.getId(),
+//                notice.getPubDate(),
+//                notice.getTitle(),
+//                notice.getUrl(),
+//                notice.isImportant()
+//        );
+//    }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryEntryNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryEntryNotice.java
@@ -22,18 +22,18 @@ public class DormitoryEntryNotice extends BaseEntity {
 
     private String campus;
 
-    private boolean isImportant;
+    private boolean important;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public DormitoryEntryNotice(String title, String url, LocalDate pubDate, String campus, boolean isImportant, Univ univ) {
+    public DormitoryEntryNotice(String title, String url, LocalDate pubDate, String campus, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
         this.campus = campus;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/DormitoryNotice.java
@@ -22,19 +22,19 @@ public class DormitoryNotice extends BaseEntity {
 
     private String campus;
 
-    private boolean isImportant;
+    private boolean important;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
 
     @Builder
-    public DormitoryNotice(String title, String url, LocalDate pubDate, String campus, boolean isImportant, Univ univ) {
+    public DormitoryNotice(String title, String url, LocalDate pubDate, String campus, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
         this.campus = campus;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/LibraryNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/LibraryNotice.java
@@ -22,19 +22,19 @@ public class LibraryNotice extends BaseEntity {
 
     private String campus;
 
-    private boolean isImportant;
+    private boolean important;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public LibraryNotice(String title, String url, LocalDate pubDate, String campus, boolean isImportant,  Univ univ) {
+    public LibraryNotice(String title, String url, LocalDate pubDate, String campus, boolean important,  Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
         this.campus = campus;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/TeachingNotice.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/TeachingNotice.java
@@ -20,17 +20,17 @@ public class TeachingNotice extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private boolean isImportant;
+    private boolean important;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "univ_id")
     private Univ univ;
 
     @Builder
-    public TeachingNotice(String title, String url, LocalDate pubDate, boolean isImportant, Univ univ) {
+    public TeachingNotice(String title, String url, LocalDate pubDate, boolean important, Univ univ) {
         this.title = title;
         this.url = url;
         this.pubDate = pubDate;
-        this.isImportant = isImportant;
+        this.important = important;
         this.univ = univ;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DormitoryEntryNoticeRepository extends JpaRepository<DormitoryEntryNotice, Long> {
-    Page<DormitoryEntryNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<DormitoryEntryNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DormitoryNoticeRepository extends JpaRepository<DormitoryNotice, Long> {
-    Page<DormitoryNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<DormitoryNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LibraryNoticeRepository extends JpaRepository<LibraryNotice, Long> {
-    Page<LibraryNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<LibraryNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeachingNoticeRepository extends JpaRepository<TeachingNotice, Long> {
-    Page<TeachingNotice> findAllByOrderByIsImportantDescPubDateDesc(Pageable pageable);
+    Page<TeachingNotice> findAllByOrderByImportantDescPubDateDesc(Pageable pageable);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/AcademicNoticeService.java
@@ -1,8 +1,12 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.notice.dto.AcademicNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.AcademicNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.AcademicNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.repository.BookmarkRepository;
+import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +15,33 @@ import java.util.stream.Collectors;
 
 @Service
 public class AcademicNoticeService {
+    private final BookmarkService bookmarkService;
     private final AcademicNoticeRepository academicNoticeRepository;
 
-    public AcademicNoticeService(AcademicNoticeRepository academicNoticeRepository) {
+    public AcademicNoticeService(BookmarkService bookmarkService, AcademicNoticeRepository academicNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.academicNoticeRepository = academicNoticeRepository;
     }
 
-    public List<AcademicNoticeDTO> getAllAcademicNotices(boolean important) throws NotFoundException {
+    public List<AcademicNoticeDTO> getAllAcademicNotices(boolean important, String ssaid) throws NotFoundException {
         List<AcademicNotice> notices = academicNoticeRepository.findByImportant(important);
         if (notices == null || notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new AcademicNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl(), notice.isImportant()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return AcademicNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .important(notice.isImportant())
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/BiddingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/BiddingNoticeService.java
@@ -1,11 +1,10 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
-import depth.mvp.thinkerbell.domain.notice.dto.StudentActsNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.BiddingNotice;
-import depth.mvp.thinkerbell.domain.notice.entity.StudentActsNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.BiddingNoticeRepository;
-import depth.mvp.thinkerbell.domain.notice.repository.StudentActsNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -14,20 +13,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class BiddingNoticeService {
+    private final BookmarkService bookmarkService;
     private final BiddingNoticeRepository biddingNoticeRepository;
 
-    public BiddingNoticeService(BiddingNoticeRepository biddingNoticeRepository) {
+    public BiddingNoticeService(BookmarkService bookmarkService, BiddingNoticeRepository biddingNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.biddingNoticeRepository = biddingNoticeRepository;
     }
 
-    public List<BiddingNoticeDTO> getAllBiddingNotices() throws NotFoundException {
+    public List<BiddingNoticeDTO> getAllBiddingNotices(String ssaid) throws NotFoundException {
         List<BiddingNotice> notices = biddingNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new BiddingNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return BiddingNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/CareerNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/CareerNoticeService.java
@@ -1,8 +1,11 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.CareerNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.CareerNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.CareerNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +14,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class CareerNoticeService {
+    private final BookmarkService bookmarkService;
     private final CareerNoticeRepository careerNoticeRepository;
 
-    public CareerNoticeService(CareerNoticeRepository careerNoticeRepository) {
+    public CareerNoticeService(BookmarkService bookmarkService, CareerNoticeRepository careerNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.careerNoticeRepository = careerNoticeRepository;
     }
 
-    public List<CareerNoticeDTO> getAllCareerNotices() throws NotFoundException {
+    public List<CareerNoticeDTO> getAllCareerNotices(String ssaid) throws NotFoundException {
         List<CareerNotice> notices = careerNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new CareerNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return CareerNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
@@ -2,8 +2,10 @@ package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.DormitoryEntryNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryEntryNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.DormitoryEntryNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,9 +17,13 @@ import java.util.stream.Collectors;
 
 @Service
 public class DormitoryEntryNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private DormitoryEntryNoticeRepository dormitoryEntryNoticeRepository;
+
+    public DormitoryEntryNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
 
 //    public List<DormitoryEntryNoticeDTO> getAllEntryNotices() {
 //        return dormitoryEntryNoticeRepository.findAll().stream().map(notice -> new DormitoryEntryNoticeDTO(
@@ -26,12 +32,29 @@ public class DormitoryEntryNoticeService {
 //        )).collect(Collectors.toList());
 //    }
 
-    public PaginationDTO<DormitoryEntryNoticeDTO> getImportantNotices(int page, int size) {
+    public PaginationDTO<DormitoryEntryNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<DormitoryEntryNotice> resultPage = dormitoryEntryNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<DormitoryEntryNotice> resultPage = dormitoryEntryNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<DormitoryEntryNoticeDTO> dtoList = resultPage.stream()
+//                .map(DormitoryEntryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<DormitoryEntryNoticeDTO> dtoList = resultPage.stream()
-                .map(DormitoryEntryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return DormitoryEntryNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
 
         return new PaginationDTO<>(

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
@@ -4,6 +4,7 @@ import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.DormitoryNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,9 +16,13 @@ import java.util.stream.Collectors;
 
 @Service
 public class DormitoryNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private DormitoryNoticeRepository dormitoryNoticeRepository;
+
+    public DormitoryNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
 
 //    public List<DormitoryNoticeDTO> getAllNotices() {
 //        return dormitoryNoticeRepository.findAll().stream().map(notice -> new DormitoryNoticeDTO(
@@ -26,14 +31,30 @@ public class DormitoryNoticeService {
 //        )).collect(Collectors.toList());
 //    }
 
-    public PaginationDTO<DormitoryNoticeDTO> getImportantNotices(int page, int size) {
+    public PaginationDTO<DormitoryNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<DormitoryNotice> resultPage = dormitoryNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<DormitoryNotice> resultPage = dormitoryNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<DormitoryNoticeDTO> dtoList = resultPage.stream()
+//                .map(DormitoryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<DormitoryNoticeDTO> dtoList = resultPage.stream()
-                .map(DormitoryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return DormitoryNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
-
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/EventNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/EventNoticeService.java
@@ -3,6 +3,7 @@ package depth.mvp.thinkerbell.domain.notice.service;
 import depth.mvp.thinkerbell.domain.notice.dto.EventNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.EventNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.EventNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +12,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class EventNoticeService {
+    private final BookmarkService bookmarkService;
     private final EventNoticeRepository eventNoticeRepository;
 
-    public EventNoticeService(EventNoticeRepository eventNoticeRepository) {
+    public EventNoticeService(BookmarkService bookmarkService, EventNoticeRepository eventNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.eventNoticeRepository = eventNoticeRepository;
     }
 
-    public List<EventNoticeDTO> getAllEventNotices() throws NotFoundException {
+    public List<EventNoticeDTO> getAllEventNotices(String ssaid) throws NotFoundException {
         List<EventNotice> notices = eventNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new EventNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return EventNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/JobTrainingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/JobTrainingNoticeService.java
@@ -1,9 +1,11 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.JobTrainingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.JobTrainingNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.JobTrainingNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,18 +17,41 @@ import java.util.stream.Collectors;
 
 @Service
 public class JobTrainingNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private JobTrainingNoticeRepository jobTrainingNoticeRepository;
 
-    public PaginationDTO<JobTrainingNoticeDTO> getJobTrainingNotices(int page, int size) {
+    public JobTrainingNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    public PaginationDTO<JobTrainingNoticeDTO> getJobTrainingNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
         Page<JobTrainingNotice> resultPage = jobTrainingNoticeRepository.findAll(pageable);
 
-        List<JobTrainingNoticeDTO> dtoList = resultPage.stream()
-                .map(JobTrainingNoticeDTO::fromEntity)
-                .collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
 
+//        List<JobTrainingNoticeDTO> dtoList = resultPage.stream()
+//                .map(JobTrainingNoticeDTO::fromEntity)
+//                .collect(Collectors.toList());
+        List<JobTrainingNoticeDTO> dtoList = resultPage.stream()
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return JobTrainingNoticeDTO.builder()
+                            .company(notice.getCompany())
+                            .year(notice.getYear())
+                            .semester(notice.getSemester())
+                            .period(notice.getPeriod())
+                            .major(notice.getMajor())
+                            .recrutingNum(notice.getRecrutingNum())
+                            .deadline(notice.getDeadline())
+                            .jobName(notice.getJobName())
+                            .marked(isMarked)
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
+                .collect(Collectors.toList());
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
@@ -2,22 +2,29 @@ package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.LibraryNoticeDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.TeachingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.LibraryNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.LibraryNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 public class LibraryNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private LibraryNoticeRepository libraryNoticeRepository;
+
+    public LibraryNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
 
 //    public List<LibraryNoticeDTO> getAllLibraryNotices() {
 //        return libraryNoticeRepository.findAll().stream().map(notice -> new LibraryNoticeDTO(
@@ -25,14 +32,31 @@ public class LibraryNoticeService {
 //        )).collect(Collectors.toList());
 //    }
 
-    public PaginationDTO<LibraryNoticeDTO> getImportantNotices(int page, int size) {
+    public PaginationDTO<LibraryNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<LibraryNotice> resultPage = libraryNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<LibraryNotice> resultPage = libraryNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<LibraryNoticeDTO> dtoList = resultPage.stream()
+//                .map(LibraryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<LibraryNoticeDTO> dtoList = resultPage.stream()
-                .map(LibraryNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return LibraryNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .campus(notice.getCampus())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
-
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NormalNoticeService.java
@@ -3,6 +3,7 @@ package depth.mvp.thinkerbell.domain.notice.service;
 import depth.mvp.thinkerbell.domain.notice.dto.NormalNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.NormalNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.NormalNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +12,33 @@ import java.util.stream.Collectors;
 
 @Service
 public class NormalNoticeService {
+    private final BookmarkService bookmarkService;
     private final NormalNoticeRepository normalNoticeRepository;
 
-    public NormalNoticeService(NormalNoticeRepository normalNoticeRepository) {
+    public NormalNoticeService(BookmarkService bookmarkService, NormalNoticeRepository normalNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.normalNoticeRepository = normalNoticeRepository;
     }
 
-    public List<NormalNoticeDTO> getAllNormalNotices(boolean important) throws NotFoundException {
+    public List<NormalNoticeDTO> getAllNormalNotices(boolean important, String ssaid) throws NotFoundException {
         List<NormalNotice> notices = normalNoticeRepository.findByImportant(important);
         if (notices == null || notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new NormalNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl(), notice.isImportant()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return NormalNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .important(notice.isImportant())
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/RevisionNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/RevisionNoticeService.java
@@ -1,8 +1,10 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.RevisionNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.RevisionNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.RevisionNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +13,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class RevisionNoticeService {
+    private final BookmarkService bookmarkService;
     private final RevisionNoticeRepository revisionNoticeRepository;
 
-    public RevisionNoticeService(RevisionNoticeRepository revisionNoticeRepository) {
+    public RevisionNoticeService(BookmarkService bookmarkService, RevisionNoticeRepository revisionNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.revisionNoticeRepository = revisionNoticeRepository;
     }
 
-    public List<RevisionNoticeDTO> getAllRevisionNotices() throws NotFoundException {
+    public List<RevisionNoticeDTO> getAllRevisionNotices(String ssaid) throws NotFoundException {
         List<RevisionNotice> notices = revisionNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new RevisionNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return RevisionNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/SafetyNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/SafetyNoticeService.java
@@ -1,8 +1,12 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.SafetyNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.SafetyNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.SafetyNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +15,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class SafetyNoticeService {
+    private final BookmarkService bookmarkService;
     private final SafetyNoticeRepository safetyNoticeRepository;
 
-    public SafetyNoticeService(SafetyNoticeRepository safetyNoticeRepository) {
+    public SafetyNoticeService(BookmarkService bookmarkService, SafetyNoticeRepository safetyNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.safetyNoticeRepository = safetyNoticeRepository;
     }
 
-    public List<SafetyNoticeDTO> getAllSafetyNotices() throws NotFoundException {
+    public List<SafetyNoticeDTO> getAllSafetyNotices(String ssaid) throws NotFoundException {
         List<SafetyNotice> notices = safetyNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new SafetyNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return SafetyNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScholarshipNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/ScholarshipNoticeService.java
@@ -3,6 +3,7 @@ package depth.mvp.thinkerbell.domain.notice.service;
 import depth.mvp.thinkerbell.domain.notice.dto.ScholarshipNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.ScholarshipNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.ScholarshipNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +12,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class ScholarshipNoticeService {
+    private final BookmarkService bookmarkService;
     private final ScholarshipNoticeRepository scholarshipNoticeRepository;
 
-    public ScholarshipNoticeService(ScholarshipNoticeRepository scholarshipNoticeRepository) {
+    public ScholarshipNoticeService(BookmarkService bookmarkService, ScholarshipNoticeRepository scholarshipNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.scholarshipNoticeRepository = scholarshipNoticeRepository;
     }
 
-    public List<ScholarshipNoticeDTO> getAllScholarshipNotices() throws NotFoundException {
+    public List<ScholarshipNoticeDTO> getAllScholarshipNotices(String ssaid) throws NotFoundException {
         List<ScholarshipNotice> notices = scholarshipNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new ScholarshipNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return ScholarshipNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/StudentActsNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/StudentActsNoticeService.java
@@ -1,8 +1,10 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
+import depth.mvp.thinkerbell.domain.notice.dto.BiddingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.StudentActsNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.StudentActsNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.StudentActsNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -11,20 +13,32 @@ import java.util.stream.Collectors;
 
 @Service
 public class StudentActsNoticeService {
+    private final BookmarkService bookmarkService;
     private final StudentActsNoticeRepository studentActsNoticeRepository;
 
-    public StudentActsNoticeService(StudentActsNoticeRepository studentActsNoticeRepository) {
+    public StudentActsNoticeService(BookmarkService bookmarkService, StudentActsNoticeRepository studentActsNoticeRepository) {
+        this.bookmarkService = bookmarkService;
         this.studentActsNoticeRepository = studentActsNoticeRepository;
     }
 
-    public List<StudentActsNoticeDTO> getAllStudentActsNotices() throws NotFoundException {
+    public List<StudentActsNoticeDTO> getAllStudentActsNotices(String ssaid) throws NotFoundException {
         List<StudentActsNotice> notices = studentActsNoticeRepository.findAll();
         if (notices.isEmpty()) {
             throw new NotFoundException("저장된 공지사항이 없습니다.");
         }
-        return notices.stream().map(notice -> new StudentActsNoticeDTO(
-                notice.getId(), notice.getPubDate(), notice.getTitle(), notice.getUrl()
-        )).collect(Collectors.toList());
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+        return notices.stream().map(notice -> {
+            boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+
+            return StudentActsNoticeDTO.builder()
+                    .id(notice.getId())
+                    .pubDate(notice.getPubDate())
+                    .title(notice.getTitle())
+                    .url(notice.getUrl())
+                    .marked(isMarked)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
@@ -1,9 +1,11 @@
 package depth.mvp.thinkerbell.domain.notice.service;
 
 import depth.mvp.thinkerbell.domain.common.pagination.PaginationDTO;
+import depth.mvp.thinkerbell.domain.notice.dto.DormitoryNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.dto.TeachingNoticeDTO;
 import depth.mvp.thinkerbell.domain.notice.entity.TeachingNotice;
 import depth.mvp.thinkerbell.domain.notice.repository.TeachingNoticeRepository;
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,18 +17,38 @@ import java.util.stream.Collectors;
 
 @Service
 public class TeachingNoticeService {
-
+    private final BookmarkService bookmarkService;
     @Autowired
     private TeachingNoticeRepository teachingNoticeRepository;
 
-    public PaginationDTO<TeachingNoticeDTO> getImportantNotices(int page, int size) {
+    public TeachingNoticeService(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    public PaginationDTO<TeachingNoticeDTO> getImportantNotices(int page, int size, String ssaid) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<TeachingNotice> resultPage = teachingNoticeRepository.findAllByOrderByIsImportantDescPubDateDesc(pageable);
+        Page<TeachingNotice> resultPage = teachingNoticeRepository.findAllByOrderByImportantDescPubDateDesc(pageable);
 
+        List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
+                this.getClass().getSimpleName().replace("Service", ""));
+
+//        List<TeachingNoticeDTO> dtoList = resultPage.stream()
+//                .map(TeachingNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+//                .collect(Collectors.toList());
         List<TeachingNoticeDTO> dtoList = resultPage.stream()
-                .map(TeachingNoticeDTO::fromEntity)  // DTO 클래스 내의 메서드 호출
+                .map(notice -> {
+                    boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
+                    return TeachingNoticeDTO.builder()
+                            .id(notice.getId())
+                            .pubDate(notice.getPubDate())
+                            .title(notice.getTitle())
+                            .url(notice.getUrl())
+                            .marked(isMarked)
+                            .important(notice.isImportant())
+                            .build();
+                })
+                // DTO 클래스 내의 메서드 호출
                 .collect(Collectors.toList());
-
         return new PaginationDTO<>(
                 dtoList,
                 resultPage.getNumber(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
@@ -1,0 +1,54 @@
+package depth.mvp.thinkerbell.domain.user.controller;
+
+import depth.mvp.thinkerbell.domain.user.service.BookmarkService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/bookmark")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @Operation(summary = "공지사항 즐겨찾기 설정", description = "공지사항을 즐겨찾기합니다. (false -> true)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 저장됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @PostMapping("")
+    public ApiResult<?> saveBookmark(@RequestParam("category") String category,
+                                     @RequestParam("notice-id") Long noticeId,
+                                     @RequestParam("user-id") Long userId) {
+        try {
+            bookmarkService.saveBookmark(category, noticeId, userId);
+            return ApiResult.ok("성공적으로 저장됨");
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+
+    @Operation(summary = "공지사항 즐겨찾기 취소", description = "공지사항을 즐겨찾기 취소합니다. (true -> false)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 삭제됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @DeleteMapping("")
+    public ApiResult<?> deleteBookmark(@RequestParam("category") String category,
+                                     @RequestParam("notice-id") Long noticeId,
+                                     @RequestParam("user-id") Long userId) {
+        try {
+            bookmarkService.deleteBookmark(category, noticeId, userId);
+            return ApiResult.ok("성공적으로 삭제됨");
+        } catch (RuntimeException e) {
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/BookmarkController.java
@@ -25,9 +25,9 @@ public class BookmarkController {
     @PostMapping("")
     public ApiResult<?> saveBookmark(@RequestParam("category") String category,
                                      @RequestParam("notice-id") Long noticeId,
-                                     @RequestParam("user-id") Long userId) {
+                                     @RequestParam("ssaid") String ssaid) {
         try {
-            bookmarkService.saveBookmark(category, noticeId, userId);
+            bookmarkService.saveBookmark(category, noticeId, ssaid);
             return ApiResult.ok("성공적으로 저장됨");
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
@@ -43,9 +43,9 @@ public class BookmarkController {
     @DeleteMapping("")
     public ApiResult<?> deleteBookmark(@RequestParam("category") String category,
                                      @RequestParam("notice-id") Long noticeId,
-                                     @RequestParam("user-id") Long userId) {
+                                     @RequestParam("ssaid") String ssaid) {
         try {
-            bookmarkService.deleteBookmark(category, noticeId, userId);
+            bookmarkService.deleteBookmark(category, noticeId, ssaid);
             return ApiResult.ok("성공적으로 삭제됨");
         } catch (RuntimeException e) {
             return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Bookmark.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Bookmark.java
@@ -16,16 +16,16 @@ public class Bookmark {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long noticeID;
-    private String noticeType;
+    private String category;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @Builder
-    public Bookmark(Long noticeID, String noticeType, User user) {
+    public Bookmark(Long noticeID, String category, User user) {
         this.noticeID = noticeID;
-        this.noticeType = noticeType;
+        this.category = category;
         this.user = user;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/repository/BookmarkRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/repository/BookmarkRepository.java
@@ -1,0 +1,14 @@
+package depth.mvp.thinkerbell.domain.user.repository;
+
+import depth.mvp.thinkerbell.domain.user.entity.Bookmark;
+import depth.mvp.thinkerbell.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    List<Bookmark> findByUserAndCategory(User user, String category);
+    Bookmark findByCategoryAndNoticeIDAndUser(String category, Long NoticeId, User user);
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
@@ -1,0 +1,45 @@
+package depth.mvp.thinkerbell.domain.user.service;
+
+import depth.mvp.thinkerbell.domain.user.entity.Bookmark;
+import depth.mvp.thinkerbell.domain.user.entity.User;
+import depth.mvp.thinkerbell.domain.user.repository.BookmarkRepository;
+import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+
+    public Bookmark saveBookmark(String category, Long noticeId, Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+        if (bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user) != null){
+            throw new NotFoundException("이미 즐겨찾기한 공지입니다.");
+        }else {
+            return bookmarkRepository.save(Bookmark.builder()
+                    .category(category)
+                    .noticeID(noticeId)
+                    .user(user)
+                    .build());
+        }
+    }
+
+    public void deleteBookmark(String category, Long noticeId, Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+        Bookmark bookmark = bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user);
+        if (bookmark == null) {
+            new NotFoundException("즐겨찾기 내역을 찾을 수 없습니다.");
+        }
+        bookmarkRepository.deleteById(bookmark.getId());
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -17,9 +19,17 @@ public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final UserRepository userRepository;
 
-    public Bookmark saveBookmark(String category, Long noticeId, Long userId) {
+    public List<Long> getBookmark(String ssaid, String category) {
+        User user = userRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
 
-        User user = userRepository.findById(userId)
+        return bookmarkRepository.findByUserAndCategory(user, category)
+                .stream()
+                .map(Bookmark::getNoticeID).toList();
+    }
+    public Bookmark saveBookmark(String category, Long noticeId, String ssaid) {
+
+        User user = userRepository.findBySsaid(ssaid)
                 .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
         if (bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user) != null){
             throw new NotFoundException("이미 즐겨찾기한 공지입니다.");
@@ -31,10 +41,9 @@ public class BookmarkService {
                     .build());
         }
     }
+    public void deleteBookmark(String category, Long noticeId, String ssaid) {
 
-    public void deleteBookmark(String category, Long noticeId, Long userId) {
-
-        User user = userRepository.findById(userId)
+        User user = userRepository.findBySsaid(ssaid)
                 .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
         Bookmark bookmark = bookmarkRepository.findByCategoryAndNoticeIDAndUser(category, noticeId, user);
         if (bookmark == null) {


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 명지대 공지사항 (일반, 행사, 학사, 진로/취업/창업, 학생활동, 장학/학자금, 안전, 개정, 입찰)에 대한 즐겨찾기 반환값 추가 
- [x] 현장실습, 도서관, 생활관(일반, 입퇴사), 교직 공지에 대한 즐겨찾기 반환값 추가

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
눈에 띄는 변경사항을 아래 기재합니다.
1. 각 DTO에 대하여 빌더 패턴 적용
  - 기존 DTO는 @NoArgsConstructor가 클래스에 적용되고, 모든 필드에 대한 생성자에 @Builder가 적용되는 방식으로 구현되어있었습니다. 이러한 방식의 경우 필요한 필드만을 선택하여 빌더 패턴을 사용할 수 있다는 장점이 있으나, 현재 코드는 모든 필드를 초기화할 때만 사용하므로 이에 맞추어 클래스에 적용되는 어노테이션을 @AllArgsConstructor, @Builder로 바꾸고 기존의 생성자는 삭제했습니다.
2. isImportant -> important 변수명 변경
  - 이전 PR에서 설명했듯 명지대 공지사항(일반, 학사)에 대해 isImportant -> important로 변수명을 변경한 것과 마찬가지로 생활관, 도서관, 교직 공지에도 변수명을 수정했습니다. 영은님께서 이미 수정하여 PR 올리신 내용은 봤으나, 아직 해당 내용이 develop 브런치에 병합되지 않아서 bookmark브런치에서도 직접 수정했습니다.
  - 그래서 아마 두 PR을 함께 병합하면 conflict가 생길 수 있을 것 같아서, PR 승인 시 머지는 일단 하지 말아주세요! conflict 확인 후 머지하도록 하겠습니다:) 
3. NoticeType -> Category 변수명 변경
  - RDS 컬럼명도 변경해두었습니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
