### PR TITLE
[FIX] 현장실습 참여 기업 공지 id 추가

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/NoticeSearchService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/NoticeSearchService.java
@@ -100,6 +100,7 @@ public class NoticeSearchService {
         List<JobTrainingNoticeDTO> jobTrainingNotices = jobTrainingNoticeRepository.searchByTitleOrMajor(keyword)
                 .stream()
                 .map(notice -> new JobTrainingNoticeDTO(
+                        notice.getId(),
                         notice.getCompany(),
                         notice.getYear(),
                         notice.getSemester(),

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/JobTrainingNoticeDTO.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/dto/JobTrainingNoticeDTO.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class JobTrainingNoticeDTO {
+    private Long id;
+
     private String company;
     private String year;
     private String semester;
@@ -19,6 +21,7 @@ public class JobTrainingNoticeDTO {
     // 엔티티를 DTO로 변환하는 정적 메서드
     public static JobTrainingNoticeDTO fromEntity(JobTrainingNotice notice) {
         return new JobTrainingNoticeDTO(
+                notice.getId(),
                 notice.getCompany(),
                 notice.getYear(),
                 notice.getSemester(),


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
- 현장실습 참여 기업 공지 id 추가

## To Reviewers 💬
참고로, 지금 현장실습 참여 기업 중에 진행중인게 없어서, 크롤링해도 데이터가 하나도 없네욧!

아오 ㄱ왜 새로운 브랜치를 팠는데도 옛날에 햇던 커밋들이 불러와지죠,..?
제가 이 브랜치에서 새롭게 추가한거는 [[fix] JobTrainingNoticeDTO id 추가] 입니다.