### PR TITLE
[FEATURE] 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/depth/mvp/thinkerbell/domain/common/service/CategoryService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/common/service/CategoryService.java
@@ -1,0 +1,34 @@
+package depth.mvp.thinkerbell.domain.common.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+@Service
+public class CategoryService {
+
+    private Map<String, String> categoryMap;
+
+    public CategoryService() {
+        loadCategoryMap();
+    }
+
+    private void loadCategoryMap() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try(InputStream inputStream = new ClassPathResource("Categories.json").getInputStream()) {
+            categoryMap = objectMapper.readValue(inputStream, new TypeReference<Map<String, String>>() {});
+        } catch (IOException e) {
+            throw new RuntimeException("카테고리 메핑 파일을 로드하는 동안 오류가 발생했습니다.",e);
+        }
+    }
+
+    public String getCategoryNameInKorean(String category) {
+        return categoryMap.getOrDefault(category, category);
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/CrawlingNum.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/entity/CrawlingNum.java
@@ -1,14 +1,12 @@
 package depth.mvp.thinkerbell.domain.notice.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
+@Setter
 @Table(name = "Crawling_Num")
 public class CrawlingNum {
 

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AllNoticeViewRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AllNoticeViewRepository.java
@@ -10,4 +10,10 @@ import java.util.List;
 public interface AllNoticeViewRepository extends JpaRepository<AllNoticesView, Long> {
     @Query(value = "SELECT * FROM All_Notices_View e WHERE REPLACE(e.title, ' ', '') LIKE %:keyword%", nativeQuery = true)
     List<AllNoticesView> findByTitleContainingKeyword(@Param("keyword") String keyword);
+
+    @Query(value = "SELECT * FROM All_Notices_View WHERE table_name = :category AND id > :maxId", nativeQuery = true)
+    List<AllNoticesView> findNewNoticesByCategory(@Param("category") String category, @Param("maxId") Long maxId);
+
+    @Query(value = "SELECT MAX(id) FROM All_Notices_View WHERE table_name = :category", nativeQuery = true)
+    Long findMaxIdByCategory(@Param("category") String category);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/CrawlingNumRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/CrawlingNumRepository.java
@@ -1,0 +1,10 @@
+package depth.mvp.thinkerbell.domain.notice.repository;
+
+import depth.mvp.thinkerbell.domain.notice.entity.CrawlingNum;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CrawlingNumRepository extends JpaRepository<CrawlingNum, Long> {
+    Optional<CrawlingNum> findByNoticeType(String noticeType);
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
@@ -1,0 +1,78 @@
+package depth.mvp.thinkerbell.domain.user.controller;
+
+import depth.mvp.thinkerbell.domain.user.dto.AlarmDto;
+import depth.mvp.thinkerbell.domain.user.service.AlarmService;
+import depth.mvp.thinkerbell.global.dto.ApiResult;
+import depth.mvp.thinkerbell.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/alarm")
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @Operation(summary = "미확인 알림 여부 확인", description = "사용자 SSAID와 키워드로 미확인 알림이 있는지 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/check")
+    public ApiResult<Boolean> checkUnviewedAlarm(@RequestParam String SSAID, @RequestParam String keyword) {
+        try {
+            boolean hasUnviewed = alarmService.hasUnviewedAlarm(SSAID, keyword);
+            return ApiResult.ok(hasUnviewed);
+        } catch (IllegalArgumentException e){
+            return ApiResult.withError(ErrorCode.INVALID_INPUT_VALUE);
+        } catch (RuntimeException e){
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "알람 읽음 처리", description = "특정 알람을 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/mark-viewed")
+    public ApiResult<String> markAsViewed(@RequestParam Long alarmId) {
+        try {
+            alarmService.markAsViewed(alarmId);
+            return ApiResult.ok("알림이 성공적으로 읽음 처리되었습니다.");
+        } catch (IllegalArgumentException e){
+            return ApiResult.withError(ErrorCode.INVALID_INPUT_VALUE, "잘못된 입력 값");
+        } catch (RuntimeException e){
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, "서버 오류 발생");
+        }
+    }
+
+    @Operation(summary = "알람 조회", description = "키워드와 사용자 SSAID로 알람을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/get")
+    public ApiResult<List<AlarmDto>> getAlarm(@RequestParam String SSAID, @RequestParam String keyword) {
+        try {
+            List<AlarmDto> alarms = alarmService.getAlarms(SSAID, keyword);
+            return ApiResult.ok(alarms);
+        } catch (IllegalArgumentException e){
+            return ApiResult.withError(ErrorCode.INVALID_INPUT_VALUE, null);
+        } catch (RuntimeException e){
+            return ApiResult.withError(ErrorCode.INTERNAL_SERVER_ERROR, null);
+        }
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/dto/AlarmDto.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/dto/AlarmDto.java
@@ -1,0 +1,30 @@
+package depth.mvp.thinkerbell.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AlarmDto {
+
+    private Long id;
+    private String title;
+    private String noticeType;
+    private Boolean isViewed;
+    private String Url;
+    private String pubDate;
+
+
+    @Builder
+    public AlarmDto(Long id, String title, String noticeType, Boolean isViewed, String Url, String pubDate) {
+        this.id = id;
+        this.title = title;
+        this.noticeType = noticeType;
+        this.isViewed = isViewed;
+        this.Url = Url;
+        this.pubDate = pubDate;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Alarm.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/entity/Alarm.java
@@ -1,14 +1,12 @@
 package depth.mvp.thinkerbell.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
+@Setter
 @Table(name = "Alarm")
 public class Alarm {
 
@@ -17,15 +15,20 @@ public class Alarm {
     private Long id;
     private Long noticeID;
     private String noticeType;
+    private String title;
+    private String keyword;
+    private Boolean isViewed = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @Builder
-    public Alarm(Long noticeID, String noticeType, User user) {
+    public Alarm(Long noticeID, String noticeType, User user, String title, String keyword) {
         this.noticeID = noticeID;
         this.noticeType = noticeType;
         this.user = user;
+        this.title = title;
+        this.keyword = keyword;
     }
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/repository/AlarmRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/repository/AlarmRepository.java
@@ -1,0 +1,13 @@
+package depth.mvp.thinkerbell.domain.user.repository;
+
+import depth.mvp.thinkerbell.domain.user.entity.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+    boolean existsByUserIdAndKeywordAndIsViewedFalse(Long userId, String keyword);
+
+    List<Alarm> findALLByUserIdAndKeyword (Long userId, String keyword);
+
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
@@ -1,0 +1,203 @@
+package depth.mvp.thinkerbell.domain.user.service;
+
+import depth.mvp.thinkerbell.domain.common.service.CategoryService;
+import depth.mvp.thinkerbell.domain.notice.entity.AllNoticesView;
+import depth.mvp.thinkerbell.domain.notice.entity.CrawlingNum;
+import depth.mvp.thinkerbell.domain.notice.repository.AllNoticeViewRepository;
+import depth.mvp.thinkerbell.domain.notice.repository.CrawlingNumRepository;
+import depth.mvp.thinkerbell.domain.user.dto.AlarmDto;
+import depth.mvp.thinkerbell.domain.user.entity.Alarm;
+import depth.mvp.thinkerbell.domain.user.entity.Keyword;
+import depth.mvp.thinkerbell.domain.user.entity.User;
+import depth.mvp.thinkerbell.domain.user.repository.AlarmRepository;
+import depth.mvp.thinkerbell.domain.user.repository.KeywordRepository;
+import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlarmService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final AllNoticeViewRepository allNoticeViewRepository;
+    private final KeywordRepository keywordRepository;
+    private final CrawlingNumRepository crawlingNumRepository;
+    private final AlarmRepository alarmRepository;
+    private final UserRepository userRepository;
+    private final FCMService fcmService;
+    private final CategoryService categoryService;
+
+    //전체 공지사항이 있는 뷰에서 키워드에 일치하는 공지를 찾아서 알람 테이블에 저장하는 기능
+    //이때 최신으로 업데이트된 공지사항만 탐색한다.
+    //알람 테이블에 저장되는 것들은 바로 fcm 알림까지 전송된다.
+    @Scheduled(cron = "0 0 10-22/3 * * ?")
+    public void updateNoticeAndMatchKeyword(){
+        List<CrawlingNum> crawlingNums;
+
+        try {
+            crawlingNums = crawlingNumRepository.findAll();
+        } catch (Exception e) {
+            throw new RuntimeException("크롤링 번호 레코드를 가져오는 동안 오류가 발생했습니다.", e);
+        }
+
+        for (CrawlingNum crawlingNum : crawlingNums) {
+            List<AllNoticesView> allNoticesViews;
+
+            try {
+                allNoticesViews = allNoticeViewRepository.findNewNoticesByCategory(crawlingNum.getNoticeType(), crawlingNum.getNoticeID());
+
+            } catch (Exception e) {
+                throw new RuntimeException(crawlingNum.getNoticeType() + "의 새로운 공지사항을 가져오는 중 오류가 발생했습니다.", e);
+            }
+
+            for (Keyword keyword : keywordRepository.findAll()) {
+                for (AllNoticesView notice : allNoticesViews) {
+                    String titleWithoutSpace = notice.getTitle().replace(" ", "");
+
+                    if (titleWithoutSpace.contains(keyword.getKeyword())) {
+                        try{
+                            Alarm alarm = new Alarm(notice.getId(), notice.getTableName(), keyword.getUser(), notice.getTitle(), keyword.getKeyword());
+
+                            alarmRepository.save(alarm);
+
+                            fcmService.sendFCMMessage(alarm, keyword.getKeyword());
+                        } catch (Exception e) {
+                            throw new RuntimeException("유저 알림을 저장하거나, fcm 알림을 보내는 도중 오류가 발생했습니다.", e);
+                        }
+                    }
+                }
+            }
+
+            //크롤링번호 최신화
+            try {
+                Long newMaxID = allNoticeViewRepository.findMaxIdByCategory(crawlingNum.getNoticeType());
+
+                Optional<CrawlingNum> existingCrawlingNumOpt = crawlingNumRepository.findByNoticeType(crawlingNum.getNoticeType());
+
+                if (existingCrawlingNumOpt.isPresent()) {
+                    // 존재하는 경우 업데이트
+                    CrawlingNum existingCrawlingNum = existingCrawlingNumOpt.get();
+                    existingCrawlingNum.setNoticeID(newMaxID);
+                    crawlingNumRepository.save(existingCrawlingNum);
+                } else {
+                    // 존재하지 않는 경우 새로 저장
+                    CrawlingNum newCrawlingNum = CrawlingNum.builder()
+                            .noticeID(newMaxID)
+                            .noticeType(crawlingNum.getNoticeType())
+                            .build();
+                    crawlingNumRepository.save(newCrawlingNum);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(crawlingNum.getNoticeType() + "의 크롤링 번호를 업데이트 하는 도중 오류가 발생했습니다.", e);
+            }
+        }
+    }
+
+    //보지 않은 알림이 있으면 true, 없으면 false
+    public boolean hasUnviewedAlarm(String SSAID, String keyword){
+        Optional<User> userOpt = userRepository.findBySsaid(SSAID);
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+
+            return alarmRepository.existsByUserIdAndKeywordAndIsViewedFalse(user.getId(), keyword);
+        }
+        return false;
+    }
+
+    //안본거 본걸로 바꾸기
+    public void markAsViewed(Long alarmID){
+        Alarm alarm = alarmRepository.findById(alarmID)
+                .orElseThrow(() -> new EntityNotFoundException("해당 id의 알림이 없습니다."));
+        alarm.setIsViewed(true);
+    }
+
+    //알림 키워드, 사용자 기반 조회
+    public List<AlarmDto> getAlarms(String SSAID, String keyword){
+        Optional<User> userOpt = userRepository.findBySsaid(SSAID);
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+
+            List<Alarm> alarms = alarmRepository.findALLByUserIdAndKeyword(user.getId(), keyword);
+            List<AlarmDto> alarmDtos = new ArrayList<>();
+
+            for (Alarm alarm : alarms) {
+                if (Objects.equals(alarm.getNoticeType(), "job_training_notice")){
+                    String pubDate = getNoticeDetail(alarm.getNoticeType(), alarm.getNoticeID());
+
+                    AlarmDto alarmDto = AlarmDto.builder()
+                            .id(alarm.getId())
+                            .title(alarm.getTitle())
+                            .noticeType(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .isViewed(alarm.getIsViewed())
+                            .Url(null)
+                            .pubDate(pubDate)
+                            .build();
+
+                    alarmDtos.add(alarmDto);
+                } else {
+                    Map<String, Object> noticeDetails = getNoticeDetails(alarm.getNoticeType(), alarm.getNoticeID());
+
+                    String url = (String) noticeDetails.get("url");
+                    String pubDate = (String) noticeDetails.get("pubDate");
+
+                    AlarmDto alarmDto = AlarmDto.builder()
+                            .id(alarm.getId())
+                            .title(alarm.getTitle())
+                            .noticeType(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .isViewed(alarm.getIsViewed())
+                            .Url(url)
+                            .pubDate(pubDate)
+                            .build();
+
+                    alarmDtos.add(alarmDto);
+                }
+            }
+
+            return alarmDtos;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private Map<String, Object> getNoticeDetails(String tableName, Long noticeID) {
+        String sql = "SELECT url, DATE_FORMAT(pub_date, '%Y-%m-%d') as pubDate FROM " + tableName + " WHERE id = :noticeID";
+
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("noticeID", noticeID);
+
+        List<Object[]> results = query.getResultList();
+
+        if (!results.isEmpty()) {
+            Object[] row = results.get(0);
+            Map<String, Object> resultMap = new HashMap<>();
+            resultMap.put("url", row[0]);
+            resultMap.put("pubDate", row[1]);
+            return resultMap;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    public String getNoticeDetail(String tableName, Long noticeID) {
+        String sql = "SELECT semester FROM " + tableName + " WHERE id = :noticeID";
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("noticeID", noticeID);
+
+        Object result = query.getSingleResult();
+        return result != null ? result.toString() : null;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/FCMService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/FCMService.java
@@ -6,6 +6,8 @@ import depth.mvp.thinkerbell.domain.user.entity.Alarm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class FCMService {
@@ -21,17 +23,14 @@ public class FCMService {
                     keyword, category, cutTitle);
 
             Message message = Message.builder()
-                    .setAndroidConfig(AndroidConfig.builder()
-                            .setNotification(AndroidNotification.builder()
-                                    .setTitle("띵커벨")
-                                    .setBody(messageBody)
-                                    .build())
-                            .build())
+                    .putData("title", "띵커벨")
+                    .putData("body", messageBody)
+                    .putData("notification_id", UUID.randomUUID().toString()) // 고유한 ID
                     .setToken(alarm.getUser().getFcmToken())
                     .build();
 
-            String responce = FirebaseMessaging.getInstance().send(message);
-            System.out.println("전송 성공" + responce);
+            String response = FirebaseMessaging.getInstance().send(message);
+            System.out.println("전송 성공" + response);
         } catch (Exception e){
             throw new RuntimeException("FCM 알림을 전송하는 동안 오류가 발생했습니다.",e);
         }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/FCMService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/FCMService.java
@@ -1,0 +1,46 @@
+package depth.mvp.thinkerbell.domain.user.service;
+
+import com.google.firebase.messaging.*;
+import depth.mvp.thinkerbell.domain.common.service.CategoryService;
+import depth.mvp.thinkerbell.domain.user.entity.Alarm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FCMService {
+
+    private final CategoryService categoryService;
+
+    public void sendFCMMessage(Alarm alarm, String keyword) {
+        try{
+            String category = categoryService.getCategoryNameInKorean(alarm.getNoticeType());
+            String cutTitle = cutTitle(alarm.getTitle(), 30);
+
+            String messageBody = String.format("‘띵~🔔 %s와(과) 관련한 공지가 올라왔어요!’\n\n[%s] %s",
+                    keyword, category, cutTitle);
+
+            Message message = Message.builder()
+                    .setAndroidConfig(AndroidConfig.builder()
+                            .setNotification(AndroidNotification.builder()
+                                    .setTitle("띵커벨")
+                                    .setBody(messageBody)
+                                    .build())
+                            .build())
+                    .setToken(alarm.getUser().getFcmToken())
+                    .build();
+
+            String responce = FirebaseMessaging.getInstance().send(message);
+            System.out.println("전송 성공" + responce);
+        } catch (Exception e){
+            throw new RuntimeException("FCM 알림을 전송하는 동안 오류가 발생했습니다.",e);
+        }
+    }
+
+    private String cutTitle(String title, int maxLength) {
+        if (title.length() > maxLength) {
+            return title.substring(0, maxLength - 1) + "…"; // 말줄임표 추가
+        }
+        return title;
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/global/config/FirebaseConfig.java
+++ b/src/main/java/depth/mvp/thinkerbell/global/config/FirebaseConfig.java
@@ -1,0 +1,25 @@
+package depth.mvp.thinkerbell.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        FileInputStream serviceAccount = new FileInputStream("src/main/resources/firebase/neverland-thinkerbell-firebase-adminsdk-n4ik2-49baee872c.json");
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/java/depth/mvp/thinkerbell/global/config/FirebaseConfig.java
+++ b/src/main/java/depth/mvp/thinkerbell/global/config/FirebaseConfig.java
@@ -14,12 +14,15 @@ public class FirebaseConfig {
 
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
-        FileInputStream serviceAccount = new FileInputStream("src/main/resources/firebase/neverland-thinkerbell-firebase-adminsdk-n4ik2-49baee872c.json");
+        if (FirebaseApp.getApps().isEmpty()) {
+            FileInputStream serviceAccount = new FileInputStream("src/main/resources/firebase/neverland-thinkerbell-firebase-adminsdk-n4ik2-49baee872c.json");
 
-        FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        return FirebaseApp.initializeApp(options);
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            return FirebaseApp.initializeApp(options);
+        } else {
+            return FirebaseApp.getInstance();
+        }
     }
 }

--- a/src/main/resources/Categories.json
+++ b/src/main/resources/Categories.json
@@ -1,0 +1,15 @@
+{
+  "academic_notice": "학사 공지",
+  "bidding_notice": "입철 공지",
+  "career_notice": "진로/취업/창업 공지",
+  "dormitory_entry_notice": "기숙사 입/퇴사 공지",
+  "dormitory_notice": "기숙사 공지",
+  "event_notice": "행사 공지",
+  "job_training_notice": "현장 실습 지원 공지",
+  "library_notice": "도서관 공지",
+  "normal_notice": "일반 공지",
+  "revision_notice": "학칙개정 사전공고",
+  "scholarship_notice": "장학/학자금 공지",
+  "student_acts_notice": "학생활동 공지",
+  "teaching_notice": "교직 공지"
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 스케쥴러를 넣어서 크롤링 시간 이후에 자동으로 알림 전송
- [x] 카테고리(테이블 명) 한글 변환 기능 추가
- [x] 알림 키워드 별 조회 기능 및 필요 정보 DTO제공
- [x] 읽지 않은 알림 조회 가능, 알림 읽음 처리 가능
- [x] FCM 알림 형식 제작
- [x] FCM 알림 전송 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
오전 10시 부터 오후 11시까지 3시간 간격으로 새로 크롤링된 공지사항에 한하여 알림이 가도록 했습니다.
Token 받아서 알림 정상적으로 가는것 확인했습니다.
알림 테이블에서 키워드 별로 미확인 알림 확인, 알림 읽음 처리, 키워드 별 알림 조회 기능 추가했습니다.
common/service에 카테고리 (테이블 명)을 한글로 바꿀 수 있는 로직 추가했습니다. (필요하시면 쓰시면 됩니다 ^^7)
JPA로는 여러 테이블 조회 및 다양한 작업에 제한이 있어서 SQL문 직접 작성하여 진행했습니다.
현재 저장되어 있는 데이터 기준으로 문제없이 작동 됩니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
https://adjh54.tistory.com/438
https://velog.io/@yujeong136/Android-notification-생성-관련-추가-정리