### PR TITLE
[FIX] 페이지네이션 관련 수정 및 반환값 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 
 ### VS Code ###
 .vscode/
+src/main/resources/firebase/neverland-thinkerbell-firebase-adminsdk-n4ik2-49baee872c.json

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
@@ -33,7 +33,7 @@ public class DormitoryEntryNoticeService {
             List<DormitoryEntryNotice> importantNotices = dormitoryEntryNoticeRepository.findAllByImportantTrueOrderByPubDateDesc();
 
             // 최신 공지사항 가져오기 (최대 10개)
-            Pageable latestPageable = PageRequest.of(0, 10);
+            Pageable latestPageable = PageRequest.of(page, size);
             Page<DormitoryEntryNotice> latestNoticesPage = dormitoryEntryNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(latestPageable);
 
             // DTO 변환
@@ -68,13 +68,13 @@ public class DormitoryEntryNoticeService {
 
             return new PaginationDTO<>(
                     dtoList,
-                    0, // 첫 페이지 번호
+                    page, // 첫 페이지 번호
                     dtoList.size(), // 가져온 항목의 개수
                     importantNotices.size() + latestNoticesPage.getTotalElements() // 총 항목 수
             );
         } else {
             // 이후 페이지: 최신 공지사항만 페이지네이션
-            Pageable pageable = PageRequest.of(page - 1, size);  // 첫 페이지는 이미 처리했으므로 page - 1
+            Pageable pageable = PageRequest.of(page, size);
             Page<DormitoryEntryNotice> resultPage = dormitoryEntryNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(pageable);
 
             List<DormitoryEntryNoticeDTO> dtoList = resultPage.stream()
@@ -92,11 +92,13 @@ public class DormitoryEntryNoticeService {
                     })
                     .collect(Collectors.toList());
 
+            int importantNoticesSize = dormitoryEntryNoticeRepository.findAllByImportantTrueOrderByPubDateDesc().size();
+
             return new PaginationDTO<>(
                     dtoList,
-                    resultPage.getNumber() + 1, // 페이지 번호를 1 추가하여 반환
+                    resultPage.getNumber(),
                     resultPage.getSize(),
-                    resultPage.getTotalElements()
+                    importantNoticesSize + resultPage.getTotalElements()
             );
         }
     }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
@@ -48,6 +48,7 @@ public class DormitoryEntryNoticeService {
                                 .url(notice.getUrl())
                                 .marked(isMarked)
                                 .important(notice.isImportant())
+                                .campus(notice.getCampus())
                                 .build();
                     })
                     .collect(Collectors.toList());
@@ -63,6 +64,7 @@ public class DormitoryEntryNoticeService {
                                 .url(notice.getUrl())
                                 .marked(isMarked)
                                 .important(notice.isImportant())
+                                .campus(notice.getCampus())
                                 .build();
                     }).toList());
 
@@ -88,6 +90,7 @@ public class DormitoryEntryNoticeService {
                                 .url(notice.getUrl())
                                 .marked(isMarked)
                                 .important(notice.isImportant())
+                                .campus(notice.getCampus())
                                 .build();
                     })
                     .collect(Collectors.toList());

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
@@ -47,6 +47,7 @@ public class DormitoryNoticeService {
                                 .title(notice.getTitle())
                                 .url(notice.getUrl())
                                 .marked(isMarked)
+                                .campus(notice.getCampus())
                                 .important(notice.isImportant())
                                 .build();
                     })
@@ -62,6 +63,7 @@ public class DormitoryNoticeService {
                                 .title(notice.getTitle())
                                 .url(notice.getUrl())
                                 .marked(isMarked)
+                                .campus(notice.getCampus())
                                 .important(notice.isImportant())
                                 .build();
                     }).toList());
@@ -88,6 +90,7 @@ public class DormitoryNoticeService {
                                 .url(notice.getUrl())
                                 .marked(isMarked)
                                 .important(notice.isImportant())
+                                .campus(notice.getCampus())
                                 .build();
                     })
                     .collect(Collectors.toList());

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryNoticeService.java
@@ -33,7 +33,7 @@ public class DormitoryNoticeService {
             List<DormitoryNotice> importantNotices = dormitoryNoticeRepository.findAllByImportantTrueOrderByPubDateDesc();
 
             // 최신 공지사항 가져오기 (최대 10개)
-            Pageable latestPageable = PageRequest.of(0, 10);
+            Pageable latestPageable = PageRequest.of(page, size);
             Page<DormitoryNotice> latestNoticesPage = dormitoryNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(latestPageable);
 
             // DTO 변환
@@ -68,13 +68,13 @@ public class DormitoryNoticeService {
 
             return new PaginationDTO<>(
                     dtoList,
-                    0, // 첫 페이지 번호
+                    page, // 첫 페이지 번호
                     dtoList.size(), // 가져온 항목의 개수
                     importantNotices.size() + latestNoticesPage.getTotalElements() // 총 항목 수
             );
         } else {
             // 그 이후 페이지: 최신 공지사항만 페이지네이션
-            Pageable pageable = PageRequest.of(page - 1, size);  // 첫 페이지는 이미 처리했으므로 page - 1
+            Pageable pageable = PageRequest.of(page, size);
             Page<DormitoryNotice> resultPage = dormitoryNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(pageable);
 
             List<DormitoryNoticeDTO> dtoList = resultPage.stream()
@@ -92,12 +92,13 @@ public class DormitoryNoticeService {
                     })
                     .collect(Collectors.toList());
 
+            int importantNoticesSize = dormitoryNoticeRepository.findAllByImportantTrueOrderByPubDateDesc().size();
 
             return new PaginationDTO<>(
                     dtoList,
-                    resultPage.getNumber() + 1, // 페이지 번호를 1 추가하여 반환
+                    resultPage.getNumber(),
                     resultPage.getSize(),
-                    resultPage.getTotalElements()
+                    importantNoticesSize + resultPage.getTotalElements()
             );
         }
     }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/JobTrainingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/JobTrainingNoticeService.java
@@ -36,6 +36,7 @@ public class JobTrainingNoticeService {
                 .map(notice -> {
                     boolean isMarked = bookmarkedNoticeIds.contains(notice.getId());
                     return JobTrainingNoticeDTO.builder()
+                            .id(notice.getId())
                             .company(notice.getCompany())
                             .year(notice.getYear())
                             .semester(notice.getSemester())

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
@@ -34,7 +34,7 @@ public class LibraryNoticeService {
             List<LibraryNotice> importantNotices = libraryNoticeRepository.findAllByImportantTrueOrderByPubDateDesc();
 
             // 최신 공지사항 가져오기 (최대 10개)
-            Pageable latestPageable = PageRequest.of(0, 10);
+            Pageable latestPageable = PageRequest.of(page, size);
             Page<LibraryNotice> latestNoticesPage = libraryNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(latestPageable);
 
             // DTO 변환
@@ -69,13 +69,13 @@ public class LibraryNoticeService {
 
             return new PaginationDTO<>(
                     dtoList,
-                    0, // 첫 페이지 번호
+                    page,
                     dtoList.size(), // 가져온 항목의 개수
                     importantNotices.size() + latestNoticesPage.getTotalElements() // 총 항목 수
             );
         } else {
             // 첫 페이지가 아닌 경우 최신 공지사항만 처리
-            Pageable pageable = PageRequest.of(page - 1, size);  // 첫 페이지는 이미 처리했으므로 page - 1
+            Pageable pageable = PageRequest.of(page, size);
             Page<LibraryNotice> resultPage = libraryNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(pageable);
 
             List<LibraryNoticeDTO> dtoList = resultPage.stream()
@@ -93,11 +93,13 @@ public class LibraryNoticeService {
                     })
                     .collect(Collectors.toList());
 
+            int importantNoticesSize = libraryNoticeRepository.findAllByImportantTrueOrderByPubDateDesc().size();
+
             return new PaginationDTO<>(
                     dtoList,
-                    resultPage.getNumber() + 1, // 페이지 번호를 1 추가하여 반환
+                    resultPage.getNumber(),
                     resultPage.getSize(),
-                    resultPage.getTotalElements()
+                    importantNoticesSize + resultPage.getTotalElements()
             );
         }
     }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
@@ -49,6 +49,7 @@ public class LibraryNoticeService {
                                 .url(notice.getUrl())
                                 .marked(isMarked)
                                 .important(notice.isImportant())
+                                .campus(notice.getCampus())
                                 .build();
                     })
                     .collect(Collectors.toList());
@@ -64,6 +65,7 @@ public class LibraryNoticeService {
                                 .url(notice.getUrl())
                                 .marked(isMarked)
                                 .important(notice.isImportant())
+                                .campus(notice.getCampus())
                                 .build();
                     }).toList());
 
@@ -89,6 +91,7 @@ public class LibraryNoticeService {
                                 .url(notice.getUrl())
                                 .marked(isMarked)
                                 .important(notice.isImportant())
+                                .campus(notice.getCampus())
                                 .build();
                     })
                     .collect(Collectors.toList());

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/TeachingNoticeService.java
@@ -33,7 +33,7 @@ public class TeachingNoticeService {
             List<TeachingNotice> importantNotices = teachingNoticeRepository.findAllByImportantTrueOrderByPubDateDesc();
 
             // 최신 공지사항 가져오기 (최대 10개)
-            Pageable latestPageable = PageRequest.of(0, 10);
+            Pageable latestPageable = PageRequest.of(page, size);
             Page<TeachingNotice> latestNoticesPage = teachingNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(latestPageable);
 
             // DTO 변환
@@ -68,13 +68,13 @@ public class TeachingNoticeService {
 
             return new PaginationDTO<>(
                     dtoList,
-                    0, // 첫 페이지 번호
+                    page,
                     dtoList.size(), // 가져온 항목의 개수
                     importantNotices.size() + latestNoticesPage.getTotalElements() // 총 항목 수
             );
         } else {
             // 이후 페이지: 최신 공지사항만 페이지네이션
-            Pageable pageable = PageRequest.of(page - 1, size);  // 첫 페이지는 이미 처리했으므로 page - 1
+            Pageable pageable = PageRequest.of(page, size);
             Page<TeachingNotice> resultPage = teachingNoticeRepository.findAllByImportantFalseOrderByPubDateDesc(pageable);
 
             List<TeachingNoticeDTO> dtoList = resultPage.stream()
@@ -92,11 +92,13 @@ public class TeachingNoticeService {
                     })
                     .collect(Collectors.toList());
 
+            int importantNoticesSize = teachingNoticeRepository.findAllByImportantTrueOrderByPubDateDesc().size();
+
             return new PaginationDTO<>(
                     dtoList,
-                    resultPage.getNumber() + 1, // 페이지 번호를 1 추가하여 반환
+                    resultPage.getNumber(),
                     resultPage.getSize(),
-                    resultPage.getTotalElements()
+                    importantNoticesSize + resultPage.getTotalElements()
             );
         }
     }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 생활관, 도서관, 교직 페이지네이션 로직 변경 
- [x] 생활관, 도서관 반환값 campus 추가
- [x] 현장실습 반환값 id 추가 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 이전에 영은님께서 현장실습 반환값 id 추가해주셨었는데, 제가 즐겨찾기 기능 변경하며 내용이 빠진 것 같아 다시 추가했습니다. 추가로 생활관, 도서관 반환값에 campus도 추가하였습니다.
- 생활관, 도서관, 교직 페이지네이션에 있어서 0페이지와 1페이지에서 같은 일반공지(중요공지가 아닌것을 말함)이 표시되는 문제, totalItems의 개수가 0페이지에서와 1 이상의 페이지에서 다르게 표시되는 문제가 있어 해결했습니다. 내용 수정하면서 코드 내에 불필요하게 상수로 표시된 부분이 있어 이 부분도 함께 수정했습니다.


## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
