### PR TITLE
[FEATURE] 기숙사, 도서관 전체 공지 조회 기능 추가

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
@@ -1,6 +1,7 @@
 package depth.mvp.thinkerbell.domain.notice.repository;
 
 import depth.mvp.thinkerbell.domain.notice.entity.DormitoryEntryNotice;
+import depth.mvp.thinkerbell.domain.notice.entity.DormitoryNotice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,11 +14,13 @@ public interface DormitoryEntryNoticeRepository extends JpaRepository<DormitoryE
     @Query("SELECT n FROM DormitoryEntryNotice n WHERE n.title LIKE CONCAT('%', :keyword, '%')")
     List<DormitoryEntryNotice> searchByTitle(@Param("keyword") String keyword);
 
-    // 모든 중요 공지사항을 가져오는 메서드
-    List<DormitoryEntryNotice> findAllByImportantTrueAndCampusOrderByPubDateDesc(String campus);
+    // 중요 공지사항을 모두 가져오는 메서드
+    @Query("SELECT d FROM DormitoryEntryNotice d WHERE d.important = true AND d.campus IN :campuses ORDER BY d.pubDate DESC")
+    List<DormitoryEntryNotice> findAllByImportantTrueAndCampusOrderByPubDateDesc(@Param("campuses") List<String> campuses);
 
     // 중요하지 않은 공지사항을 페이지네이션하여 가져오는 메서드
-    Page<DormitoryEntryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, String campus);
+    @Query("SELECT d FROM DormitoryEntryNotice d WHERE d.important = false AND d.campus IN :campuses ORDER BY d.pubDate DESC")
+    Page<DormitoryEntryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, @Param("campuses") List<String> campuses);
 
     DormitoryEntryNotice findOneById(Long noticeID);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
@@ -14,10 +14,12 @@ public interface DormitoryNoticeRepository extends JpaRepository<DormitoryNotice
     List<DormitoryNotice> searchByTitle(@Param("keyword") String keyword);
 
     // 중요 공지사항을 모두 가져오는 메서드
-    List<DormitoryNotice> findAllByImportantTrueAndCampusOrderByPubDateDesc(String campus);
+    @Query("SELECT d FROM DormitoryNotice d WHERE d.important = true AND d.campus IN :campuses ORDER BY d.pubDate DESC")
+    List<DormitoryNotice> findAllByImportantTrueAndCampusOrderByPubDateDesc(@Param("campuses") List<String> campuses);
 
     // 중요하지 않은 공지사항을 페이지네이션하여 가져오는 메서드
-    Page<DormitoryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, String campus);
+    @Query("SELECT d FROM DormitoryNotice d WHERE d.important = false AND d.campus IN :campuses ORDER BY d.pubDate DESC")
+    Page<DormitoryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, @Param("campuses") List<String> campuses);
 
     DormitoryNotice findOneById(Long id);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
@@ -1,5 +1,6 @@
 package depth.mvp.thinkerbell.domain.notice.repository;
 
+import depth.mvp.thinkerbell.domain.notice.entity.DormitoryEntryNotice;
 import depth.mvp.thinkerbell.domain.notice.entity.LibraryNotice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,11 +14,12 @@ public interface LibraryNoticeRepository extends JpaRepository<LibraryNotice, Lo
     @Query("SELECT n FROM LibraryNotice n WHERE n.title LIKE CONCAT('%', :keyword, '%')")
     List<LibraryNotice> searchByTitle(@Param("keyword") String keyword);
 
-    // 중요 공지사항을 가져오는 메서드
-    List<LibraryNotice> findAllByImportantTrueAndCampusOrderByPubDateDesc(String campus);
+    @Query("SELECT d FROM LibraryNotice d WHERE d.important = true AND d.campus IN :campuses ORDER BY d.pubDate DESC")
+    List<LibraryNotice> findAllByImportantTrueAndCampusOrderByPubDateDesc(@Param("campuses") List<String> campuses);
 
     // 중요하지 않은 공지사항을 페이지네이션하여 가져오는 메서드
-    Page<LibraryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, String campus);
+    @Query("SELECT d FROM LibraryNotice d WHERE d.important = false AND d.campus IN :campuses ORDER BY d.pubDate DESC")
+    Page<LibraryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, @Param("campuses") List<String> campuses);
 
     LibraryNotice findOneById(Long noticeID);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/DormitoryEntryNoticeService.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,13 +30,22 @@ public class DormitoryEntryNoticeService {
         // USER가 북마크한 내역(id리스트) 가져오기
         List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
                 this.getClass().getSimpleName().replace("Service", ""));
+
+        List<String> campuses;
+
+        if ("전체".equals(campus)){
+            campuses = Arrays.asList("인문", "자연", "공통");
+        } else {
+            campuses = Collections.singletonList(campus);
+        }
+
         if (page == 0) {
             // 첫 번째 페이지: 중요 공지사항 모두 가져오기
-            List<DormitoryEntryNotice> importantNotices = dormitoryEntryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campus);
+            List<DormitoryEntryNotice> importantNotices = dormitoryEntryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campuses);
 
             // 최신 공지사항 가져오기 (최대 10개)
             Pageable latestPageable = PageRequest.of(page, size);
-            Page<DormitoryEntryNotice> latestNoticesPage = dormitoryEntryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(latestPageable, campus);
+            Page<DormitoryEntryNotice> latestNoticesPage = dormitoryEntryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(latestPageable, campuses);
 
             // DTO 변환
             List<DormitoryEntryNoticeDTO> dtoList = importantNotices.stream()
@@ -77,7 +88,7 @@ public class DormitoryEntryNoticeService {
         } else {
             // 이후 페이지: 최신 공지사항만 페이지네이션
             Pageable pageable = PageRequest.of(page, size);
-            Page<DormitoryEntryNotice> resultPage = dormitoryEntryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(pageable, campus);
+            Page<DormitoryEntryNotice> resultPage = dormitoryEntryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(pageable, campuses);
 
             List<DormitoryEntryNoticeDTO> dtoList = resultPage.stream()
                     .map(notice -> {
@@ -95,7 +106,7 @@ public class DormitoryEntryNoticeService {
                     })
                     .collect(Collectors.toList());
 
-            int importantNoticesSize = dormitoryEntryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campus).size();
+            int importantNoticesSize = dormitoryEntryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campuses).size();
 
             return new PaginationDTO<>(
                     dtoList,

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/LibraryNoticeService.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,14 +30,23 @@ public class LibraryNoticeService {
         // USER가 북마크한 내역(id리스트) 가져오기
         List<Long> bookmarkedNoticeIds = bookmarkService.getBookmark(ssaid,
                 this.getClass().getSimpleName().replace("Service", ""));
+
+        List<String> campuses;
+
+        if ("전체".equals(campus)){
+            campuses = Arrays.asList("인문", "자연", "공통");
+        } else {
+            campuses = Collections.singletonList(campus);
+        }
+
         if (page == 0) {
             // 첫 번째 페이지
             // 중요 공지사항 모두 가져오기
-            List<LibraryNotice> importantNotices = libraryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campus);
+            List<LibraryNotice> importantNotices = libraryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campuses);
 
             // 최신 공지사항 가져오기 (최대 10개)
             Pageable latestPageable = PageRequest.of(page, size);
-            Page<LibraryNotice> latestNoticesPage = libraryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(latestPageable, campus);
+            Page<LibraryNotice> latestNoticesPage = libraryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(latestPageable, campuses);
 
             // DTO 변환
             List<LibraryNoticeDTO> dtoList = importantNotices.stream()
@@ -78,7 +89,7 @@ public class LibraryNoticeService {
         } else {
             // 첫 페이지가 아닌 경우 최신 공지사항만 처리
             Pageable pageable = PageRequest.of(page, size);
-            Page<LibraryNotice> resultPage = libraryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(pageable, campus);
+            Page<LibraryNotice> resultPage = libraryNoticeRepository.findAllByImportantFalseAndCampusOrderByPubDateDesc(pageable, campuses);
 
             List<LibraryNoticeDTO> dtoList = resultPage.stream()
                     .map(notice -> {
@@ -96,7 +107,7 @@ public class LibraryNoticeService {
                     })
                     .collect(Collectors.toList());
 
-            int importantNoticesSize = libraryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campus).size();
+            int importantNoticesSize = libraryNoticeRepository.findAllByImportantTrueAndCampusOrderByPubDateDesc(campuses).size();
 
             return new PaginationDTO<>(
                     dtoList,


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 기숙사, 도서관 전체 공지 조회 기능 추가


## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
기숙사, 도서관 전체 공지 조회 기능 추가했습니다.
따라서 현재 인자로 인문, 자연, 공통, 전체를 받아서 각자에 맞는 결과 return합니다.
이로인해서 repository JPQL 쿼리로 변경했습니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
