### PR TITLE
[FEAT] 알람 조회 시 카테고리 영어명 추가

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
@@ -82,7 +82,7 @@ public class AlarmController {
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/get")
+    @GetMapping
     public ApiResult<List<AlarmDto>> getAlarm(@RequestParam String SSAID, @RequestParam String keyword) {
         try {
             List<AlarmDto> alarms = alarmService.getAlarms(SSAID, keyword);

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/dto/AlarmDto.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/dto/AlarmDto.java
@@ -10,7 +10,8 @@ public class AlarmDto {
 
     private Long id;
     private String title;
-    private String noticeType;
+    private String noticeType_korean;
+    private String noticeType_english;
     private boolean isViewed;
     private boolean isMarked;
     private String Url;

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
@@ -14,6 +14,7 @@ import depth.mvp.thinkerbell.domain.user.repository.AlarmRepository;
 import depth.mvp.thinkerbell.domain.user.repository.BookmarkRepository;
 import depth.mvp.thinkerbell.domain.user.repository.KeywordRepository;
 import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import depth.mvp.thinkerbell.global.converter.CaseConverter;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.PersistenceContext;
@@ -203,7 +204,8 @@ public class AlarmService {
                     AlarmDto alarmDto = AlarmDto.builder()
                             .id(alarm.getId())
                             .title(alarm.getTitle())
-                            .noticeType(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .noticeType_korean(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .noticeType_english(CaseConverter.snakeToPascal(alarm.getNoticeType()))
                             .isViewed(alarm.getIsViewed())
                             .isMarked(isMarked)
                             .Url(null)
@@ -220,7 +222,8 @@ public class AlarmService {
                     AlarmDto alarmDto = AlarmDto.builder()
                             .id(alarm.getId())
                             .title(alarm.getTitle())
-                            .noticeType(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .noticeType_korean(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
+                            .noticeType_english(CaseConverter.snakeToPascal(alarm.getNoticeType()))
                             .isViewed(alarm.getIsViewed())
                             .isMarked(isMarked)
                             .Url(url)

--- a/src/main/java/depth/mvp/thinkerbell/global/converter/CaseConverter.java
+++ b/src/main/java/depth/mvp/thinkerbell/global/converter/CaseConverter.java
@@ -1,0 +1,57 @@
+package depth.mvp.thinkerbell.global.converter;
+
+public class CaseConverter {
+
+    /**
+     * PascalCase 문자열을 snake_case 문자열로 변환합니다.
+     *
+     * @param pascalCaseString 변환할 PascalCase 문자열
+     * @return 변환된 snake_case 문자열
+     */
+    public static String pascalToSnake(String pascalCaseString) {
+        StringBuilder snakeCaseString = new StringBuilder();
+
+        for (char c : pascalCaseString.toCharArray()) {
+            if (Character.isUpperCase(c)) {
+                if (snakeCaseString.length() > 0) {
+                    snakeCaseString.append('_');
+                }
+                snakeCaseString.append(Character.toLowerCase(c));
+            } else {
+                snakeCaseString.append(c);
+            }
+        }
+
+        return snakeCaseString.toString();
+    }
+
+    /**
+     * snake_case 문자열을 PascalCase 문자열로 변환합니다.
+     *
+     * @param snakeCaseString 변환할 snake_case 문자열
+     * @return 변환된 PascalCase 문자열
+     */
+    public static String snakeToPascal(String snakeCaseString) {
+        StringBuilder pascalCaseString = new StringBuilder();
+        boolean toUpperCase = true;  // 첫 문자를 대문자로 변환하기 위해 true로 설정
+
+        for (char c : snakeCaseString.toCharArray()) {
+            if (c == '_') {
+                // 언더스코어 다음 문자를 대문자로 변환하도록 설정합니다.
+                toUpperCase = true;
+            } else {
+                if (toUpperCase) {
+                    // 대문자로 변환 후 설정을 초기화합니다.
+                    pascalCaseString.append(Character.toUpperCase(c));
+                    toUpperCase = false;
+                } else {
+                    // 소문자로 추가합니다.
+                    pascalCaseString.append(c);
+                }
+            }
+        }
+
+        return pascalCaseString.toString();
+    }
+
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 알람 조회 시 카테고리 영어명 추가
- [x] CaseConverter 추가
- [x] 알람 조회 API uri 수정 (get 삭제) 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- CaseConverter 클래스를 만들어 pascalToSnake, snakeToPascal 함수 만들어두었습니다. 실제로 프론트와 카테고리 인자를 주고받을 때는 대개 CareerNotice와 같이 파스칼표기법으로 주고받기 때문에 이러한 상황 또는 테이블명과 매치해야하는 상황 등에서 유용할 것 같습니다. 필요하실 경우 사용하시면 됩니다.

- 알람 조회 API에서 get uri 제거했습니다. RESTful API의 url 규칙 중 CRUD 메소드를 넣지 말라는 규칙이 있습니다. RESTful API 규칙/설계 이러한 키워드로 관련해서 찾아보시면 좋을 것 같습니다. (아래 레퍼런스도 하나 올렸습니다.)

- 시간 되시면 코드 설계자분께서 notice_type이라고 작성된 내용들 category로 변경해주시면 코드 통일성 측면에서 좋을 것 같습니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
https://prohannah.tistory.com/156